### PR TITLE
balance changes, bug fixes & code note adjustments

### DIFF
--- a/code/modules/fallout/obj/clothing/head/helmet.dm
+++ b/code/modules/fallout/obj/clothing/head/helmet.dm
@@ -9,7 +9,7 @@
 	icon_state = "broken"
 	item_state = "broken"
 	flags = HEADCOVERSEYES | HEADCOVERSMOUTH
-	armor = list(melee = 25, bullet = 15, laser = 20, energy = 10, bomb = 15, bio = 10, rad = 15, fire = 10, acid = 10)
+	armor = list(melee = 25, bullet = 15, laser = 10, energy = 10, bomb = 15, bio = 10, rad = 15, fire = 10, acid = 10)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 	put_on_delay = 10
 	strip_delay = 20
@@ -33,7 +33,7 @@
 	icon_state = "motorcycle"
 	item_state = "motorcycle"
 	flags = HEADCOVERSEYES
-	armor = list(melee = 30, bullet = 20, laser = 20, energy = 10, bomb = 20, bio = 10, rad = 10, fire = 20, acid = 20)
+	armor = list(melee = 30, bullet = 20, laser = 10, energy = 10, bomb = 20, bio = 10, rad = 10, fire = 20, acid = 20)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEHAIR
 	put_on_delay = 10
 	strip_delay = 10
@@ -86,7 +86,7 @@
 	icon_state = "eyebot"
 	item_state = "eyebot"
 	flags = HEADCOVERSEYES | HEADCOVERSMOUTH
-	armor = list(melee = 40, bullet = 20, laser = 20, energy = 10, bomb = 20, bio = 25, rad = 30, fire = 40, acid = 30)
+	armor = list(melee = 40, bullet = 20, laser = 10, energy = 10, bomb = 20, bio = 25, rad = 30, fire = 40, acid = 30)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 	put_on_delay = 10
 	strip_delay = 50
@@ -98,7 +98,7 @@
 	desc = "A piece of headwear commonly worn by the Great Khans that appears to resemble stereotypical traditional Mongolian helmets - likely adapted from a pre-War motorcycle helmet.<br>It is black with two horns on either side and a small spike jutting from the top, much like a pickelhaube.<br>A leather covering protects the wearer's neck and ears from sunburn."
 	icon_state = "khan"
 	item_state = "khan"
-	armor = list(melee = 40, bullet = 30, laser = 20, energy = 20, bomb = 25, bio = 20, rad = 20, fire = 20, acid = 20)
+	armor = list(melee = 40, bullet = 15, laser = 10, energy = 20, bomb = 25, bio = 20, rad = 20, fire = 20, acid = 20)
 	flags_inv = HIDEEARS|HIDEHAIR
 	put_on_delay = 10
 	strip_delay = 20
@@ -122,7 +122,7 @@
 	icon_state = "combat_mk1"
 	item_state = "combat_mk1"
 	flags = HEADCOVERSEYES
-	armor = list(melee = 40, bullet = 30, laser = 20, energy = 20, bomb = 30, bio = 0, rad = 0, fire = 20, acid = 20)
+	armor = list(melee = 40, bullet = 40, laser = 10, energy = 20, bomb = 30, bio = 0, rad = 0, fire = 20, acid = 20)
 	flags_inv = HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR
 	put_on_delay = 20
 	strip_delay = 40
@@ -134,7 +134,7 @@
 	desc = "A complex ballistic assembly, designed to protect the wearer from projectile and energy weapon impacts, bladed weapons, blunt trauma, and concussion."
 	icon_state = "combat_mk2"
 	item_state = "combat_mk2"
-	armor = list(melee = 50, bullet = 40, laser = 30, energy = 30, bomb = 40, bio = 0, rad = 0, fire = 40, acid = 40)
+	armor = list(melee = 60, bullet = 60, laser = 15, energy = 15, bomb = 40, bio = 0, rad = 0, fire = 40, acid = 40)
 	flags_inv = HIDEEARS
 	put_on_delay = 20
 	strip_delay = 30
@@ -146,7 +146,7 @@
 	desc = "A custom built ballistic helmet made with very advanced kevlar and dyneema hybrid plates for maximum protection against most projectiles. It appears to be based on an NCR ranger's helmet, including a similar night vision function."
 	icon_state = "liquidhelmet"
 	item_state = "liquidhelmet"
-	armor = list(melee = 50, bullet = 30, laser = 30, energy = 30, bomb = 30, bio = 0, rad = 80, fire = 50, acid = 20)
+	armor = list(melee = 50, bullet = 30, laser = 10, energy = 10, bomb = 30, bio = 0, rad = 80, fire = 50, acid = 20)
 	flags = HEADCOVERSEYES | HEADCOVERSMOUTH
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 	put_on_delay = 10
@@ -181,7 +181,7 @@
 	desc = "Before you lies a rusted World War II gas mask, seemingly modified to have thermal capabilities. Beside the mask is a continuous black cloth, which seems to be able to wrap around your entire head. This ensemble appears to favor those who wish to protect their identities at all costs."
 	icon_state = "huntermask"
 	item_state = "huntermask"
-	armor = list(melee = 50, bullet = 30, laser = 30, energy = 30, bomb = 30, bio = 0, rad = 80, fire = 50, acid = 20)
+	armor = list(melee = 65, bullet = 10, laser = 10, energy = 10, bomb = 30, bio = 0, rad = 80, fire = 50, acid = 20)
 	flags = HEADCOVERSEYES | HEADCOVERSMOUTH
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 	put_on_delay = 10
@@ -216,7 +216,7 @@
 	desc = "An old military helmet with a built-in night vision device which no longer seems to function. You feel depressed just looking at this ugly thing."
 	icon_state = "johnranger"
 	item_state = "johnranger"
-	armor = list(melee = 50, bullet = 30, laser = 30, energy = 30, bomb = 30, bio = 0, rad = 80, fire = 50, acid = 20)
+	armor = list(melee = 50, bullet = 15, laser = 15, energy = 15, bomb = 30, bio = 0, rad = 80, fire = 50, acid = 20)
 	flags = HEADCOVERSEYES | HEADCOVERSMOUTH
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 	put_on_delay = 10
@@ -230,7 +230,7 @@
 	desc = "A Legion recruit helmet, made of fine molerat leather. Or was it gecko leather? Come to think of it, that other guy from Legion had a helmet made of brahmin leather..."
 	icon_state = "legrecruit"
 	item_state = "legrecruit"
-	armor = list(melee = 35, bullet = 30, laser = 25, energy = 20, bomb = 25, bio = 20, rad = 25, fire = 25, acid = 25)
+	armor = list(melee = 35, bullet = 10, laser = 5, energy = 5, bomb = 55, bio = 20, rad = 25, fire = 25, acid = 25)
 	flags_inv = HIDEEARS|HIDEHAIR
 	put_on_delay = 10
 	strip_delay = 30
@@ -241,7 +241,7 @@
 	desc = "It appears to be a pitcher helmet with a red line burned into it. Vaguely smells of blood and sweat."
 	icon_state = "legprime"
 	item_state = "legprime"
-	armor = list(melee = 55, bullet = 30, laser = 25, energy = 20, bomb = 25, bio = 20, rad = 25, fire = 25, acid = 25)
+	armor = list(melee = 55, bullet = 15, laser = 5, energy = 5, bomb = 60, bio = 20, rad = 25, fire = 25, acid = 25)
 	flags_inv = HIDEEARS|HIDEHAIR
 	put_on_delay = 10
 	strip_delay = 30
@@ -252,7 +252,7 @@
 	desc = "Vis gregis est lupus, ac vis lupi est grex.<br>100% of wolf."
 	icon_state = "legvexil"
 	item_state = "legvexil"
-	armor = list(melee = 30, bullet = 30, laser = 20, energy = 20, bomb = 20, bio = 20, rad = 20, fire = 20, acid = 20)
+	armor = list(melee = 30, bullet = 25, laser = 15, energy = 15, bomb = 60, bio = 20, rad = 20, fire = 20, acid = 20)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEHAIR
 	put_on_delay = 10
 	strip_delay = 50
@@ -263,7 +263,7 @@
 	desc = "A Legion decanus helmet, made of tanned leather and decorated with feathers."
 	icon_state = "legdecan"
 	item_state = "legdecan"
-	armor = list(melee = 50, bullet = 40, laser = 30, energy = 30, bomb = 30, bio = 30, rad = 40, fire = 40, acid = 30)
+	armor = list(melee = 50, bullet = 25, laser = 15, energy = 15, bomb = 70, bio = 30, rad = 40, fire = 40, acid = 30)
 	flags_inv = HIDEEARS|HIDEHAIR
 	put_on_delay = 10
 	strip_delay = 40
@@ -282,7 +282,7 @@
 	desc = "A metal helmet commonly worn by the Centurion, a ranked officer of Caesar's Legion."
 	icon_state = "legcenturion"
 	item_state = "legcenturion"
-	armor = list(melee = 60, bullet = 50, laser = 40, energy = 30, bomb = 40, bio = 40, rad = 50, fire = 50, acid = 40)
+	armor = list(melee = 60, bullet = 35, laser = 10, energy = 10, bomb = 80, bio = 40, rad = 50, fire = 50, acid = 40)
 	flags_inv = HIDEEARS|HIDEHAIR
 	put_on_delay = 10
 	strip_delay = 50
@@ -293,7 +293,7 @@
 	desc = "A metal helmet destined to adorn the head of the Legate, a ranked officer of Caesar's Legion."
 	icon_state = "leglegate"
 	item_state = "leglegate"
-	armor = list(melee = 75, bullet = 60, laser = 50, energy = 40, bomb = 50, bio = 50, rad = 60, fire = 60, acid = 60)
+	armor = list(melee = 65, bullet = 55, laser = 20, energy = 20, bomb = 80, bio = 50, rad = 50, fire = 50, acid = 50)
 	flags = HEADCOVERSEYES | HEADCOVERSMOUTH
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 	put_on_delay = 10
@@ -307,7 +307,7 @@
 	icon = 'icons/fallout/clothing/hats.dmi'
 	icon_state = "strange"
 	item_state = "helmet"
-	armor = list(melee = 40, bullet = 30, laser = 30, energy = 25, bomb = 20, bio = 25, rad = 25, fire = 25, acid = 25)
+	armor = list(melee = 40, bullet = 25, laser = 30, energy = 25, bomb = 20, bio = 25, rad = 25, fire = 25, acid = 25)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 	cold_protection = HEAD
 	min_cold_protection_temperature = SPACE_HELM_MIN_TEMP_PROTECT
@@ -323,7 +323,7 @@
 	desc = "A helmet made of an unknown alloy.<br>You feel like this helmet would allow you to survive through Hell on Mars... er, Earth."
 	icon_state = "doom"
 	item_state = "doom"
-	armor = list(melee = 20, bullet = 20, laser = 20, energy = 20, bomb = 20, bio = 20, rad = 20, fire = 20, acid = 20)
+	armor = list(melee = 90, bullet = 90, laser = 90, energy = 90, bomb = 90, bio = 90, rad = 90, fire = 90, acid = 90)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 	put_on_delay = 30
 	strip_delay = 10
@@ -335,7 +335,7 @@
 	desc = "This helmet allows its wearer to resist all but the strongest or most unexpected telepathic attacks.<br>This is achieved due to technology wired into the helmet itself."
 	icon_state = "magneto"
 	item_state = "magneto"
-	armor = list(melee = 60, bullet = 50, laser = 50, energy = 50, bomb = 50, bio = 100, rad = 100, fire = 30, acid = 100)
+	armor = list(melee = 60, bullet = 35, laser = 25, energy = 25, bomb = 25, bio = 100, rad = 100, fire = 30, acid = 100)
 	flags_inv = HIDEEARS|HIDEHAIR
 	put_on_delay = 10
 	strip_delay = 50
@@ -380,21 +380,21 @@
 	return ..()
 	
 /obj/item/clothing/head/helmet/power_armor/badmin
-	name = "advanced mark III power helmet"
-	desc = "A group of Enclave mad scientists lead by Administrator Badmin, have spent a decade working on the incredible creation you see in front of you."
+	name = "advanced power armor Mk. IV helmet"
+	desc = "Enclave Hellfire armor is a heat-resistant power armor worn by high level Enclave soldiers and the specialized, elite Enclave Hellfire troopers."
 	icon_state = "badmin"
 	item_state = "badmin"
 	flags = HEADCOVERSEYES | HEADCOVERSMOUTH | STOPSPRESSUREDMAGE
-	armor = list(melee = 90, bullet = 90, laser = 80, energy = 80, bomb = 80, bio = 100, rad = 100, fire = 90, acid = 100)
+	armor = list(melee = 95, bullet = 95, laser = 70, energy = 70, bomb = 45, bio = 100, rad = 100, fire = 100, acid = 100)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 	cold_protection = HEAD
 	min_cold_protection_temperature = SPACE_HELM_MIN_TEMP_PROTECT
 	heat_protection = HEAD
 	max_heat_protection_temperature = SPACE_HELM_MAX_TEMP_PROTECT
-	put_on_delay = 50
-	strip_delay = 100
+	put_on_delay = 600
+	strip_delay = 600
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
-	self_weight = 3
+	self_weight = 2
 	flash_protect = 2
 	
 /obj/item/clothing/head/helmet/power_armor/badmin/ComponentInitialize()
@@ -424,21 +424,21 @@
 		A.UpdateButtonIcon()
 
 /obj/item/clothing/head/helmet/power_armor/shocktrooper
-	name = "shocktrooper power helmet"
+	name = "advanced power armor Mk. III helmet"
 	desc = "A 'black devil' power armor helmet used exclusively by Enclave military forces, developed after the Great War and the destruction of the Enclave Oil Rig in 2241.<br>You can't lie, it looks pretty badass."
 	icon_state = "shocktrooper"
 	item_state = "shocktrooper"
 	flags = HEADCOVERSEYES | HEADCOVERSMOUTH | STOPSPRESSUREDMAGE
-	armor = list(melee = 90, bullet = 90, laser = 80, energy = 65, bomb = 65, bio = 100, rad = 100, fire = 100, acid = 100)
+	armor = list(melee = 95, bullet = 95, laser = 65, energy = 60, bomb = 60, bio = 100, rad = 100, fire = 100, acid = 100)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 	cold_protection = HEAD
 	min_cold_protection_temperature = SPACE_HELM_MIN_TEMP_PROTECT
 	heat_protection = HEAD
 	max_heat_protection_temperature = SPACE_HELM_MAX_TEMP_PROTECT
-	put_on_delay = 50
-	strip_delay = 100
+	put_on_delay = 600
+	strip_delay = 600
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
-	self_weight = 3
+	self_weight = 2
 	flash_protect = 2
 	
 /obj/item/clothing/head/helmet/power_armor/shocktrooper/ComponentInitialize()
@@ -468,21 +468,21 @@
 		A.UpdateButtonIcon()
 
 /obj/item/clothing/head/helmet/power_armor/superadvanced
-	name = "advanced mark II power helmet"
-	desc = "An improved model of advanced power armor used exclusively by Enclave military forces, developed after the Great War.<br>It looks rather threatening."
+	name = "advanced power armor Mk. II helmet"
+	desc = "An improved model of the standard advanced power armor helmet used exclusively by Enclave military forces, developed after the Great War.<br>It looks rather threatening."
 	icon_state = "superadvanced"
 	item_state = "superadvanced"
 	flags = HEADCOVERSEYES | HEADCOVERSMOUTH | STOPSPRESSUREDMAGE
-	armor = list(melee = 90, bullet = 85, laser = 70, energy = 60, bomb = 60, bio = 100, rad = 100, fire = 100, acid = 100)
+	armor = list(melee = 95, bullet = 95, laser = 55, energy = 55, bomb = 55, bio = 100, rad = 100, fire = 100, acid = 100)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 	cold_protection = HEAD
 	min_cold_protection_temperature = SPACE_HELM_MIN_TEMP_PROTECT
 	heat_protection = HEAD
 	max_heat_protection_temperature = SPACE_HELM_MAX_TEMP_PROTECT
-	put_on_delay = 50
-	strip_delay = 100
+	put_on_delay = 600
+	strip_delay = 600
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
-	self_weight = 4
+	self_weight = 2
 	flash_protect = 2
 	
 /obj/item/clothing/head/helmet/power_armor/superadvanced/ComponentInitialize()
@@ -512,21 +512,21 @@
 		A.UpdateButtonIcon()
 
 /obj/item/clothing/head/helmet/power_armor/tesla
-	name = "tesla power helmet"
+	name = "advanced tesla power armor Mk. I helmet"
 	desc = "A helmet typically used by Enclave special forces.<br>There are three orange energy capacitors on the side."
 	icon_state = "tesla"
 	item_state = "tesla"
 	flags = HEADCOVERSEYES | HEADCOVERSMOUTH | STOPSPRESSUREDMAGE
-	armor = list(melee = 55, bullet = 55, laser = 90, energy = 70, bomb = 30, bio = 100, rad = 100, fire = 50, acid = 50)
+	armor = list(melee = 55, bullet = 55, laser = 95, energy = 95, bomb = 55, bio = 100, rad = 100, fire = 100, acid = 100)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 	cold_protection = HEAD
 	min_cold_protection_temperature = SPACE_HELM_MIN_TEMP_PROTECT
 	heat_protection = HEAD
 	max_heat_protection_temperature = SPACE_HELM_MAX_TEMP_PROTECT
-	put_on_delay = 50
-	strip_delay = 100
+	put_on_delay = 600
+	strip_delay = 600
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
-	self_weight = 4
+	self_weight = 2
 	flash_protect = 2
 	
 /obj/item/clothing/head/helmet/power_armor/tesla/ComponentInitialize()
@@ -556,21 +556,21 @@
 		A.UpdateButtonIcon()
 
 /obj/item/clothing/head/helmet/power_armor/advanced
-	name = "advanced mark I power helmet"
+	name = "advanced power armor Mk. I helmet"
 	desc = "A helmet typically used by Enclave regular troops.<br>It looks somewhat threatening."
 	icon_state = "advanced"
 	item_state = "advanced"
 	flags = HEADCOVERSEYES | HEADCOVERSMOUTH | STOPSPRESSUREDMAGE
-	armor = list(melee = 70, bullet = 70, laser = 60, energy = 50, bomb = 60, bio = 100, rad = 100, fire = 80, acid = 80)
+	armor = list(melee = 95, bullet = 95, laser = 50, energy = 45, bomb = 45, bio = 100, rad = 100, fire = 100, acid = 100)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 	cold_protection = HEAD
 	min_cold_protection_temperature = SPACE_HELM_MIN_TEMP_PROTECT
 	heat_protection = HEAD
 	max_heat_protection_temperature = SPACE_HELM_MAX_TEMP_PROTECT
-	put_on_delay = 50
-	strip_delay = 100
+	put_on_delay = 600
+	strip_delay = 600
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
-	self_weight = 4
+	self_weight = 2
 	flash_protect = 2
 	
 /obj/item/clothing/head/helmet/power_armor/advanced/ComponentInitialize()
@@ -605,17 +605,17 @@
 	icon_state = "t60helmet"
 	item_state = "t60helmet"
 	flags = HEADCOVERSEYES | HEADCOVERSMOUTH | STOPSPRESSUREDMAGE
-	armor = list(melee = 70, bullet = 70, laser = 45, energy = 40, bomb = 40, bio = 70, rad = 70, fire = 70, acid = 70)
+	armor = list(melee = 95, bullet = 95, laser = 35, energy = 25, bomb = 45, bio = 100, rad = 100, fire = 100, acid = 100)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 	cold_protection = HEAD
 	min_cold_protection_temperature = SPACE_HELM_MIN_TEMP_PROTECT
 	heat_protection = HEAD
 	max_heat_protection_temperature = SPACE_HELM_MAX_TEMP_PROTECT
-	put_on_delay = 50
-	strip_delay = 100
+	put_on_delay = 600
+	strip_delay = 600
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	actions_types = list(/datum/action/item_action/toggle_helmet_light)
-	self_weight = 5
+	self_weight = 2
 	flash_protect = 2
 	
 /obj/item/clothing/head/helmet/power_armor/t60/ComponentInitialize()
@@ -628,17 +628,17 @@
 	icon_state = "t51bhelmet"
 	item_state = "t51bhelmet"
 	flags = HEADCOVERSEYES | HEADCOVERSMOUTH | STOPSPRESSUREDMAGE
-	armor = list(melee = 70, bullet = 70, laser = 30, energy = 25, bomb = 25, bio = 45, rad = 45, fire = 50, acid = 50)
+	armor = list(melee = 95, bullet = 95, laser = 25, energy = 20, bomb = 45, bio = 100, rad = 100, fire = 100, acid = 100)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 	cold_protection = HEAD
 	min_cold_protection_temperature = SPACE_HELM_MIN_TEMP_PROTECT
 	heat_protection = HEAD
 	max_heat_protection_temperature = SPACE_HELM_MAX_TEMP_PROTECT
-	put_on_delay = 50
-	strip_delay = 100
+	put_on_delay = 600
+	strip_delay = 600
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	actions_types = list(/datum/action/item_action/toggle_helmet_light)
-	self_weight = 5
+	self_weight = 2
 	flash_protect = 2
 	
 /obj/item/clothing/head/helmet/power_armor/t51b/ComponentInitialize()
@@ -651,15 +651,15 @@
 	icon_state = "t45dhelmet"
 	item_state = "t45dhelmet"
 	flags = HEADCOVERSEYES | HEADCOVERSMOUTH | STOPSPRESSUREDMAGE
-	armor = list(melee = 55, bullet = 55, laser = 20, energy = 15, bomb = 15, bio = 15, rad = 15, fire = 50, acid = 50)
+	armor = list(melee = 95, bullet = 95, laser = 20, energy = 15, bomb = 40, bio =100, rad = 100, fire = 100, acid = 100)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 	cold_protection = HEAD
 	min_cold_protection_temperature = SPACE_HELM_MIN_TEMP_PROTECT
-	put_on_delay = 50
-	strip_delay = 100
+	put_on_delay = 600
+	strip_delay = 600
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	actions_types = list(/datum/action/item_action/toggle_helmet_light)
-	self_weight = 5
+	self_weight = 2
 	flash_protect = 2
 	
 /obj/item/clothing/head/helmet/power_armor/t45d/ComponentInitialize()
@@ -674,13 +674,13 @@
 	icon_state = "t45bhelmet"
 	item_state = "t45bhelmet"
 	flags = HEADCOVERSEYES | HEADCOVERSMOUTH
-	armor = list(melee = 55, bullet = 55, laser = 20, energy = 15, bomb = 15, bio = 15, rad = 15, fire = 50, acid = 50)
+	armor = list(melee = 70, bullet = 70, laser = 5, energy = 5, bomb = 15, bio = 100, rad = 100, fire = 100, acid = 100) //ncr power armour has not received the same durability boost as theb ase durability is already rather high for its 'availability' on a non-whitelisted, non-admin event faction like the NCR.
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
-	put_on_delay = 50
-	strip_delay = 100
+	put_on_delay = 600
+	strip_delay = 600
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	actions_types = list(/datum/action/item_action/toggle_helmet_light)
-	self_weight = 5
+	self_weight = 2
 	flash_protect = 2
 	
 /obj/item/clothing/head/helmet/power_armor/ncr/ComponentInitialize()

--- a/code/modules/fallout/obj/clothing/head/helmet.dm
+++ b/code/modules/fallout/obj/clothing/head/helmet.dm
@@ -358,6 +358,7 @@
 	var/on = 0
 	light_color = LIGHT_COLOR_YELLOW
 	icon = 'icons/fallout/clothing/hats.dmi'
+	flash_protect = 2
 
 /obj/item/clothing/head/helmet/power_armor/proc/toogle_light(mob/user)
 	on = !on
@@ -377,7 +378,7 @@
 		toogle_light(user)
 		return 1
 	return ..()
-
+	
 /obj/item/clothing/head/helmet/power_armor/badmin
 	name = "advanced mark III power helmet"
 	desc = "A group of Enclave mad scientists lead by Administrator Badmin, have spent a decade working on the incredible creation you see in front of you."
@@ -392,8 +393,13 @@
 	max_heat_protection_temperature = SPACE_HELM_MAX_TEMP_PROTECT
 	put_on_delay = 50
 	strip_delay = 100
-	resistance_flags = FIRE_PROOF | UNACIDABLE
+	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	self_weight = 3
+	flash_protect = 2
+	
+/obj/item/clothing/head/helmet/power_armor/badmin/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/wearertargeting/earprotection, list(SLOT_EARS))
 
 	darkness_view = 8
 	invis_view = SEE_INVISIBLE_MINIMUM
@@ -423,7 +429,7 @@
 	icon_state = "shocktrooper"
 	item_state = "shocktrooper"
 	flags = HEADCOVERSEYES | HEADCOVERSMOUTH | STOPSPRESSUREDMAGE
-	armor = list(melee = 90, bullet = 80, laser = 75, energy = 80, bomb = 80, bio = 100, rad = 100, fire = 90, acid = 90)
+	armor = list(melee = 90, bullet = 90, laser = 80, energy = 65, bomb = 65, bio = 100, rad = 100, fire = 100, acid = 100)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 	cold_protection = HEAD
 	min_cold_protection_temperature = SPACE_HELM_MIN_TEMP_PROTECT
@@ -431,8 +437,13 @@
 	max_heat_protection_temperature = SPACE_HELM_MAX_TEMP_PROTECT
 	put_on_delay = 50
 	strip_delay = 100
-	resistance_flags = FIRE_PROOF | UNACIDABLE
+	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	self_weight = 3
+	flash_protect = 2
+	
+/obj/item/clothing/head/helmet/power_armor/shocktrooper/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/wearertargeting/earprotection, list(SLOT_EARS))
 
 	darkness_view = 8
 	invis_view = SEE_INVISIBLE_MINIMUM
@@ -462,7 +473,7 @@
 	icon_state = "superadvanced"
 	item_state = "superadvanced"
 	flags = HEADCOVERSEYES | HEADCOVERSMOUTH | STOPSPRESSUREDMAGE
-	armor = list(melee = 80, bullet = 75, laser = 60, energy = 60, bomb = 70, bio = 100, rad = 80, fire = 90, acid = 90)
+	armor = list(melee = 90, bullet = 85, laser = 70, energy = 60, bomb = 60, bio = 100, rad = 100, fire = 100, acid = 100)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 	cold_protection = HEAD
 	min_cold_protection_temperature = SPACE_HELM_MIN_TEMP_PROTECT
@@ -470,8 +481,13 @@
 	max_heat_protection_temperature = SPACE_HELM_MAX_TEMP_PROTECT
 	put_on_delay = 50
 	strip_delay = 100
-	resistance_flags = FIRE_PROOF | UNACIDABLE
+	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	self_weight = 4
+	flash_protect = 2
+	
+/obj/item/clothing/head/helmet/power_armor/superadvanced/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/wearertargeting/earprotection, list(SLOT_EARS))
 
 	darkness_view = 8
 	invis_view = SEE_INVISIBLE_MINIMUM
@@ -501,7 +517,7 @@
 	icon_state = "tesla"
 	item_state = "tesla"
 	flags = HEADCOVERSEYES | HEADCOVERSMOUTH | STOPSPRESSUREDMAGE
-	armor = list(melee = 60, bullet = 50, laser = 90, energy = 90, bomb = 50, bio = 100, rad = 80, fire = 80, acid = 80)
+	armor = list(melee = 55, bullet = 55, laser = 90, energy = 70, bomb = 30, bio = 100, rad = 100, fire = 50, acid = 50)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 	cold_protection = HEAD
 	min_cold_protection_temperature = SPACE_HELM_MIN_TEMP_PROTECT
@@ -509,8 +525,13 @@
 	max_heat_protection_temperature = SPACE_HELM_MAX_TEMP_PROTECT
 	put_on_delay = 50
 	strip_delay = 100
-	resistance_flags = FIRE_PROOF | UNACIDABLE
+	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	self_weight = 4
+	flash_protect = 2
+	
+/obj/item/clothing/head/helmet/power_armor/tesla/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/wearertargeting/earprotection, list(SLOT_EARS))
 
 	darkness_view = 8
 	invis_view = SEE_INVISIBLE_MINIMUM
@@ -540,7 +561,7 @@
 	icon_state = "advanced"
 	item_state = "advanced"
 	flags = HEADCOVERSEYES | HEADCOVERSMOUTH | STOPSPRESSUREDMAGE
-	armor = list(melee = 75, bullet = 70, laser = 60, energy = 60, bomb = 75, bio = 100, rad = 80, fire = 80, acid = 80)
+	armor = list(melee = 70, bullet = 70, laser = 60, energy = 50, bomb = 60, bio = 100, rad = 100, fire = 80, acid = 80)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 	cold_protection = HEAD
 	min_cold_protection_temperature = SPACE_HELM_MIN_TEMP_PROTECT
@@ -548,8 +569,13 @@
 	max_heat_protection_temperature = SPACE_HELM_MAX_TEMP_PROTECT
 	put_on_delay = 50
 	strip_delay = 100
-	resistance_flags = FIRE_PROOF | UNACIDABLE
+	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	self_weight = 4
+	flash_protect = 2
+	
+/obj/item/clothing/head/helmet/power_armor/advanced/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/wearertargeting/earprotection, list(SLOT_EARS))
 
 	darkness_view = 8
 	invis_view = SEE_INVISIBLE_MINIMUM
@@ -579,7 +605,7 @@
 	icon_state = "t60helmet"
 	item_state = "t60helmet"
 	flags = HEADCOVERSEYES | HEADCOVERSMOUTH | STOPSPRESSUREDMAGE
-	armor = list(melee = 80, bullet = 70, laser = 60, energy = 60, bomb = 70, bio = 100, rad = 70, fire = 70, acid = 70)
+	armor = list(melee = 70, bullet = 70, laser = 45, energy = 40, bomb = 40, bio = 70, rad = 70, fire = 70, acid = 70)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 	cold_protection = HEAD
 	min_cold_protection_temperature = SPACE_HELM_MIN_TEMP_PROTECT
@@ -587,9 +613,14 @@
 	max_heat_protection_temperature = SPACE_HELM_MAX_TEMP_PROTECT
 	put_on_delay = 50
 	strip_delay = 100
-	resistance_flags = FIRE_PROOF | UNACIDABLE
+	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	actions_types = list(/datum/action/item_action/toggle_helmet_light)
 	self_weight = 5
+	flash_protect = 2
+	
+/obj/item/clothing/head/helmet/power_armor/t60/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/wearertargeting/earprotection, list(SLOT_EARS))
 
 /obj/item/clothing/head/helmet/power_armor/t51b
 	name = "T-51b power helmet"
@@ -597,7 +628,7 @@
 	icon_state = "t51bhelmet"
 	item_state = "t51bhelmet"
 	flags = HEADCOVERSEYES | HEADCOVERSMOUTH | STOPSPRESSUREDMAGE
-	armor = list(melee = 75, bullet = 60, laser = 50, energy = 50, bomb = 60, bio = 100, rad = 70, fire = 70, acid = 70)
+	armor = list(melee = 70, bullet = 70, laser = 30, energy = 25, bomb = 25, bio = 45, rad = 45, fire = 50, acid = 50)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 	cold_protection = HEAD
 	min_cold_protection_temperature = SPACE_HELM_MIN_TEMP_PROTECT
@@ -605,9 +636,14 @@
 	max_heat_protection_temperature = SPACE_HELM_MAX_TEMP_PROTECT
 	put_on_delay = 50
 	strip_delay = 100
-	resistance_flags = FIRE_PROOF | UNACIDABLE
+	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	actions_types = list(/datum/action/item_action/toggle_helmet_light)
 	self_weight = 5
+	flash_protect = 2
+	
+/obj/item/clothing/head/helmet/power_armor/t51b/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/wearertargeting/earprotection, list(SLOT_EARS))
 
 /obj/item/clothing/head/helmet/power_armor/t45d
 	name = "T-45d power helmet"
@@ -615,15 +651,20 @@
 	icon_state = "t45dhelmet"
 	item_state = "t45dhelmet"
 	flags = HEADCOVERSEYES | HEADCOVERSMOUTH | STOPSPRESSUREDMAGE
-	armor = list(melee = 70, bullet = 55, laser = 40, energy = 40, bomb = 50, bio = 100, rad = 60, fire = 60, acid = 60)
+	armor = list(melee = 55, bullet = 55, laser = 20, energy = 15, bomb = 15, bio = 15, rad = 15, fire = 50, acid = 50)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 	cold_protection = HEAD
 	min_cold_protection_temperature = SPACE_HELM_MIN_TEMP_PROTECT
 	put_on_delay = 50
 	strip_delay = 100
-	resistance_flags = FIRE_PROOF | UNACIDABLE
+	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	actions_types = list(/datum/action/item_action/toggle_helmet_light)
 	self_weight = 5
+	flash_protect = 2
+	
+/obj/item/clothing/head/helmet/power_armor/t45d/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/wearertargeting/earprotection, list(SLOT_EARS))
 
 //NCR
 
@@ -633,13 +674,18 @@
 	icon_state = "t45bhelmet"
 	item_state = "t45bhelmet"
 	flags = HEADCOVERSEYES | HEADCOVERSMOUTH
-	armor = list(melee = 40, bullet = 35, laser = 20, energy = 20, bomb = 20, bio = 20, rad = 30, fire = 30, acid = 30)
+	armor = list(melee = 55, bullet = 55, laser = 20, energy = 15, bomb = 15, bio = 15, rad = 15, fire = 50, acid = 50)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 	put_on_delay = 50
 	strip_delay = 100
-	resistance_flags = FIRE_PROOF | UNACIDABLE
+	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	actions_types = list(/datum/action/item_action/toggle_helmet_light)
 	self_weight = 5
+	flash_protect = 2
+	
+/obj/item/clothing/head/helmet/power_armor/ncr/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/wearertargeting/earprotection, list(SLOT_EARS))
 
 /obj/item/clothing/head/helmet/ncr/trooper
 	name = "trooper helmet"

--- a/code/modules/fallout/obj/clothing/suits/armor.dm
+++ b/code/modules/fallout/obj/clothing/suits/armor.dm
@@ -11,7 +11,7 @@
 	item_state = "jensencoat"
 	flags = THICKMATERIAL
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
-	armor = list(melee = 50, bullet = 30, laser = 20, energy = 20, bomb = 10, bio = 10, rad = 20, fire = 30, acid = 30)
+	armor = list(melee = 50, bullet = 30, laser = 15, energy = 15, bomb = 10, bio = 10, rad = 20, fire = 30, acid = 30)
 	allowed = list(/obj/item/weapon/pen,/obj/item/weapon/paper,/obj/item/weapon/stamp,/obj/item/weapon/reagent_containers/food/drinks/flask,/obj/item/weapon/melee,/obj/item/weapon/storage/box/matches,/obj/item/weapon/lighter,/obj/item/clothing/mask/cigarette,/obj/item/weapon/storage/fancy/cigarettes,/obj/item/device/flashlight,/obj/item/weapon/gun,/obj/item/ammo_box,/obj/item/ammo_casing)
 	resistance_flags = UNACIDABLE
 	put_on_delay = 10
@@ -24,7 +24,7 @@
 	icon_state = "praetor"
 	item_state = "g_suit"
 	body_parts_covered = CHEST
-	armor = list(melee = 10, bullet = 10, laser = 10, energy = 10, bomb = 10, bio = 10, rad = 10, fire = 10, acid = 10)
+	armor = list(melee = 60, bullet = 70, laser = 50, energy = 50, bomb = 10, bio = 10, rad = 10, fire = 10, acid = 10)
 	resistance_flags = UNACIDABLE
 	put_on_delay = 30
 	strip_delay = 10
@@ -36,7 +36,7 @@
 	icon_state = "armorkit"
 	item_state = "armorkit"
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS
-	armor = list(melee = 25, bullet = 15, laser = 5, energy = 5, bomb = 5, bio = 0, rad = 0, fire = 5, acid = 0)
+	armor = list(melee = 15, bullet = 25, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 5, acid = 0)
 	put_on_delay = 30
 	strip_delay = 30
 	self_weight = 2
@@ -47,7 +47,7 @@
 	icon_state = "punkit" //Punk it
 	item_state = "punkit" //Pun kit
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS
-	armor = list(melee = 30, bullet = 25, laser = 20, energy = 20, bomb = 15, bio = 20, rad = 20, fire = 50, acid = 50)
+	armor = list(melee = 20, bullet = 25, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 5, acid = 0)
 	put_on_delay = 30
 	strip_delay = 30
 	self_weight = 2
@@ -57,11 +57,11 @@
 	desc = "When equipped, the owner takes significantly less damage from attacks to the chest.<br>It's heavy and uncomfortable, though."
 	icon_state = "metal_chestplate"
 	item_state = "metal_chestplate"
-	body_parts_covered = CHEST
-	armor = list(melee = 40, bullet = 30, laser = 20, energy = 20, bomb = 20, bio = 0, rad = 0, fire = 10, acid = 0)
+	body_parts_covered = CHEST|GROIN
+	armor = list(melee = 50, bullet = 35, laser = 15, energy = 10, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 20)
 	put_on_delay = 30
 	strip_delay = 10
-	resistance_flags = FIRE_PROOF
+	resistance_flags = ACID_PROOF
 	self_weight = 5
 
 /obj/item/clothing/suit/armor/f13/tribal
@@ -70,7 +70,7 @@
 	icon_state = "tribal"
 	item_state = "tribal"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	armor = list(melee = 30, bullet = 15, laser = 10, energy = 10, bomb = 10, bio = 0, rad = 5, fire = 10, acid = 5)
+	armor = list(melee = 50, bullet = 15, laser = 10, energy = 5, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
 	flags_inv = HIDEJUMPSUIT
 	put_on_delay = 40
 	strip_delay = 40
@@ -82,7 +82,7 @@
 	icon_state = "slam"
 	item_state = "slam"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	armor = list(melee = 25, bullet = 15, laser = 10, energy = 10, bomb = 10, bio = 0, rad = 10, fire = 5, acid = 5)
+	armor = list(melee = 15, bullet = 25, laser = 10, energy = 5, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
 	flags_inv = HIDEJUMPSUIT
 	put_on_delay = 20
 	strip_delay = 40
@@ -94,7 +94,7 @@
 	icon_state = "supafly"
 	item_state = "supafly"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	armor = list(melee = 25, bullet = 15, laser = 10, energy = 10, bomb = 10, bio = 0, rad = 10, fire = 5, acid = 5)
+	armor = list(melee = 15, bullet = 25, laser = 10, energy = 5, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
 	flags_inv = HIDEJUMPSUIT
 	put_on_delay = 20
 	strip_delay = 40
@@ -106,7 +106,7 @@
 	icon_state = "yankee"
 	item_state = "yankee"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	armor = list(melee = 30, bullet = 25, laser = 10, energy = 10, bomb = 15, bio = 10, rad = 15, fire = 20, acid = 10)
+	armor = list(melee = 20, bullet = 20, laser = 10, energy = 5, bomb = 10, bio = 0, rad = 0, fire = 0, acid = 0)
 	flags_inv = HIDEJUMPSUIT
 	put_on_delay = 40
 	strip_delay = 40
@@ -118,7 +118,7 @@
 	icon_state = "leatherarmor"
 	item_state = "leatherarmor"
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS
-	armor = list(melee = 40, bullet = 30, laser = 15, energy = 15, bomb = 25, bio = 10, rad = 20, fire = 20, acid = 10)
+	armor = list(melee = 55, bullet = 30, laser = 5, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
 	flags_inv = HIDEJUMPSUIT
 	put_on_delay = 40
 	strip_delay = 40
@@ -130,25 +130,25 @@
 	icon_state = "metalarmor"
 	item_state = "metalarmor"
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS
-	armor = list(melee = 50, bullet = 40, laser = 35, energy = 25, bomb = 30, bio = 10, rad = 15, fire = 25, acid = 20)
+	armor = list(melee = 60, bullet = 45, laser = 5, energy = 0, bomb = 5, bio = 0, rad = 0, fire = 0, acid = 20)
 	flags_inv = HIDEJUMPSUIT
 	put_on_delay = 60
 	strip_delay = 60
-	resistance_flags = FIRE_PROOF
+	resistance_flags = ACID_PROOF
 	self_weight = 10
 
 /obj/item/clothing/suit/armor/f13/bmetalarmor
-	name = "black metal armor"
-	desc = "A set of sturdy metal armor made from various bits of scrap metal. It looks like it might impair movement."
+	name = "reinforced metal armor"
+	desc = "A set of sturdy metal armor made from various bits of scrap metal and spraypainted black. It looks like it might impair movement."
 	icon_state = "bmetalarmor"
 	item_state = "bmetalarmor"
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS
-	armor = list(melee = 40, bullet = 30, laser = 30, energy = 20, bomb = 20, bio = 0, rad = 10, fire = 20, acid = 10)
+	armor = list(melee = 65, bullet = 50, laser = 10, energy = 5, bomb = 5, bio = 0, rad = 0, fire = 0, acid = 30)
 	flags_inv = HIDEJUMPSUIT
 	put_on_delay = 60
 	strip_delay = 60
-	resistance_flags = FIRE_PROOF
-	self_weight = 15
+	resistance_flags = ACID_PROOF
+	self_weight = 20
 
 // legion armors
 
@@ -158,10 +158,10 @@
 	icon_state = "legrecruit"
 	item_state = "legrecruit"
 	body_parts_covered = CHEST|GROIN|LEGS|FEET
-	armor = list(melee = 35, bullet = 45, laser = 40, energy = 40, bomb = 60, bio = 50, rad = 50, fire = 50, acid = 50)
+	armor = list(melee = 35, bullet = 25, laser = 10, energy = 10, bomb = 5, bio = 15, rad = 10, fire = 10, acid = 10)
 	put_on_delay = 60
 	strip_delay = 60
-	self_weight = 3
+	self_weight = 4
 
 /obj/item/clothing/suit/armor/f13/legprime
 	name = "prime legionary armor"
@@ -169,10 +169,10 @@
 	icon_state = "legrecruit"
 	item_state = "legrecruit"
 	body_parts_covered = CHEST|GROIN|LEGS|FEET
-	armor = list(melee = 40, bullet = 40, laser = 50, energy = 50, bomb = 60, bio = 50, rad = 50, fire = 50, acid = 50)
+	armor = list(melee = 45, bullet = 30, laser = 10, energy = 10, bomb = 5, bio = 15, rad = 10, fire = 10, acid = 10)
 	put_on_delay = 60
 	strip_delay = 60
-	self_weight = 3
+	self_weight = 4
 
 /obj/item/clothing/suit/armor/f13/legvexil
 	name = "legion vexillarius armor"
@@ -180,7 +180,7 @@
 	icon_state = "legvexil"
 	item_state = "legvexil"
 	body_parts_covered = CHEST|GROIN|LEGS|FEET
-	armor = list(melee = 45, bullet = 45, laser = 45, energy = 45, bomb = 40, bio = 30, rad = 30, fire = 30, acid = 30)
+	armor = list(melee = 60, bullet = 30, laser = 20, energy = 15, bomb = 5, bio = 15, rad = 10, fire = 10, acid = 10)
 	put_on_delay = 60
 	strip_delay = 60
 	self_weight = 5
@@ -191,10 +191,10 @@
 	icon_state = "legcenturion"
 	item_state = "legcenturion"
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS
-	armor = list(melee = 50, bullet = 50, laser = 50, energy = 50, bomb = 70, bio = 70, rad = 80, fire = 80, acid = 80)
+	armor = list(melee = 75, bullet = 40, laser = 25, energy = 15, bomb = 10, bio = 15, rad = 10, fire = 10, acid = 10)
 	put_on_delay = 60
 	strip_delay = 60
-	self_weight = 10
+	self_weight = 8
 
 /obj/item/clothing/suit/armor/f13/legcenturion
 	name = "legion centurion armor"
@@ -202,7 +202,7 @@
 	icon_state = "legcenturion"
 	item_state = "legcenturion"
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS
-	armor = list(melee = 60, bullet = 60, laser = 60, energy = 60, bomb = 70, bio = 70, rad = 80, fire = 80, acid = 80)
+	armor = list(melee = 75, bullet = 50, laser = 25, energy = 25, bomb = 10, bio = 15, rad = 20, fire = 20, acid = 20)
 	put_on_delay = 60
 	strip_delay = 60
 	self_weight = 10
@@ -213,11 +213,11 @@
 	icon_state = "leglegate"
 	item_state = "leglegate"
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS
-	armor = list(melee = 70, bullet = 70, laser = 70, energy = 70, bomb = 75, bio = 75, rad = 90, fire = 90, acid = 90)
+	armor = list(melee = 95, bullet = 55, laser = 25, energy = 25, bomb = 35, bio = 35, rad = 20, fire = 20, acid = 20)
 	put_on_delay = 60
 	strip_delay = 60
-	resistance_flags = FIRE_PROOF
-	self_weight = 15
+	resistance_flags = FIRE_PROOF | ACID_PROOF
+	self_weight = 25
 
 // combat armors
 
@@ -227,11 +227,10 @@
 	icon_state = "combat_mk1"
 	item_state = "combat_mk1"
 	body_parts_covered = CHEST|GROIN|LEGS|FEET
-	armor = list(melee = 60, bullet = 60, laser = 23, energy = 20, bomb = 30, bio = 0, rad = 10, fire = 60, acid = 20)
+	armor = list(melee = 55, bullet = 55, laser = 20, energy = 10, bomb = 45, bio = 35, rad = 25, fire = 25, acid = 25)
 	put_on_delay = 60
 	strip_delay = 60
-	resistance_flags = FIRE_PROOF
-	self_weight = 10
+	self_weight = 5
 
 /obj/item/clothing/suit/armor/f13/combat_mk2
 	name = "reinforced combat armor mark II"
@@ -239,11 +238,10 @@
 	icon_state = "combat_mk2"
 	item_state = "combat_mk2"
 	body_parts_covered = CHEST|GROIN|LEGS|FEET
-	armor = list(melee = 70, bullet = 55, laser = 35, energy = 30, bomb = 40, bio = 0, rad = 20, fire = 50, acid = 50)
+	armor = list(melee = 70, bullet = 60, laser = 20, energy = 15, bomb = 45, bio = 35, rad = 25, fire = 25, acid = 25)
 	put_on_delay = 60
 	strip_delay = 60
-	resistance_flags = FIRE_PROOF
-	self_weight = 5
+	self_weight = 2
 
 // ncr armors
 
@@ -253,11 +251,11 @@
 	icon_state = "ncr_armor1"
 	item_state = "ncr_armor1"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	armor = list(melee = 30, bullet = 30, laser = 30, energy = 30, bomb = 20, bio = 0, rad = 20, fire = 10, acid = 20)
+	armor = list(melee = 10, bullet = 30, laser = 5, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 10, acid = 0)
 	put_on_delay = 50
 	strip_delay = 50
 	resistance_flags = FIRE_PROOF
-	self_weight = 5
+	self_weight = 4
 
 /obj/item/clothing/suit/armor/f13/ncr/recruit
 	name = "NCR reserve trooper armor"
@@ -313,7 +311,7 @@
 	icon_state = "ncr_armor9"
 	item_state = "ncr_armor9"
 	self_weight = 6
-	armor = list(melee = 40, bullet = 40, laser = 20, energy = 20, bomb = 10, bio = 0, rad = 50, fire = 20, acid = 20) //Better radiation protection, thank the facewrap bro!
+	armor = list(melee = 10, bullet = 30, laser = 5, energy = 0, bomb = 0, bio = 15, rad = 15, fire = 15, acid = 0) //Better radiation protection, thank the facewrap bro!
 	flags_inv = HIDEFACE|HIDEFACIALHAIR
 
 /obj/item/clothing/suit/armor/f13/sergeant
@@ -322,7 +320,7 @@
 	icon_state = "sergeant"
 	item_state = "sergeant"
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS
-	armor = list(melee = 45, bullet = 45, laser = 45, energy = 45, bomb = 20, bio = 0, rad = 30, fire = 30, acid = 30)
+	armor = list(melee = 20, bullet = 35, laser = 15, energy = 5, bomb = 15, bio = 5, rad = 5, fire = 15, acid = 5)
 	put_on_delay = 40
 	strip_delay = 40
 	resistance_flags = FIRE_PROOF
@@ -339,18 +337,20 @@
 	flags_inv = HIDEJUMPSUIT
 	put_on_delay = 50
 	strip_delay = 100
-	self_weight = 35
+	self_weight = 40
 	slowdown = 1
-	armor = list(melee = 55, bullet = 55, laser = 55, energy = 55, bomb = 15, bio = 40, rad = 20, fire = 40, acid = 30)
+	armor = list(melee = 70, bullet = 70, laser = 5, energy = 5, bomb = 15, bio = 100, rad = 100, fire = 100, acid = 100) //These changes aren't necessarily realistic as no servomotors = less effective at disappating oncoming force but should serve to give NCR heavy troopers an actual role in combat. Should be far better suited towards a defensive playstyle against ballistic weapons.
+	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 
 /obj/item/clothing/suit/armor/f13/power_armor/sierra
 	name = "NCR scorched sierra power armor"
 	desc = "A set of repurposed T-45d Power Armor, with a bears head mounted onto the shoulder and secured with a strap with a large gold medallion clip holding it snug. It holds a rack of cooling fans and a stream lined set of hydraulic actuators. It appears to have once been lined with a gold trim. It also appears to have a scorched layer of soot burned into it."
 	icon_state = "sierra"
 	item_state = "sierra"
-	armor = list(melee = 80, bullet = 80, laser = 80, energy = 80, bomb = 35, bio = 40, rad = 20, fire = 40, acid = 30)
-	self_weight = 30
-
+	armor = list(melee = 55, bullet = 55, laser = 20, energy = 15, bomb = 25, bio = 100, rad = 100, fire = 100, acid = 100)
+	self_weight = 25 //weight adjusted and general behaviour put more in line with regular power armour since sierra power armour is meant to have its servomotors still installed and used by captains that have been trained to use power armour
+	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+	
 // ncr armor end
 
 
@@ -372,7 +372,7 @@
 	icon_state = "rochellcoat"
 	item_state = "rochellcoat"
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS
-	armor = list(melee = 70, bullet = 60, laser = 50, energy = 50, bomb = 50, bio = 50, rad = 50, fire = 50, acid = 50)
+	armor = list(melee = 60, bullet = 40, laser = 30, energy = 30, bomb = 20, bio = 20, rad = 20, fire = 20, acid = 20)
 	put_on_delay = 20
 	strip_delay = 30
 	self_weight = 2
@@ -383,12 +383,14 @@
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS
 	flags = STOPSPRESSUREDMAGE
 	flags_inv = HIDEJUMPSUIT
-	cold_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
-	put_on_delay = 100
-	strip_delay = 200
-	resistance_flags = FIRE_PROOF | UNACIDABLE
-	self_weight = 35
+	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
+	cold_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
+	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
+	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+	self_weight = 18 //power armour uses servomotors to support its own weight, this still causes slowdown but not as ridiculous as before. means a power armour trooper can carry a backpack without reaching lowest speed possible.
+	put_on_delay = 600
+	strip_delay = 600 //strip and equip timers increased, should discourage messing around with power armour bodies honestly, power armour generally requires a team of technicians to outfit the wearer into the suit, rather than just being an easily deployed suit of combat armor.
 	special_defence = PREVENTDISMEMBER
 
 /obj/item/clothing/suit/armor/f13/power_armor/mob_can_equip(mob/user, slot)
@@ -407,66 +409,66 @@
 	desc = "Originally developed and manufactured for the United States Army by American defense contractor West Tek, the T-45d power armor was the first version of power armor to be successfully deployed in battle."
 	icon_state = "t45dpowerarmor"
 	item_state = "t45dpowerarmor"
-	armor = list(melee = 70, bullet = 70, laser = 70, energy = 70, bomb = 70, bio =100, rad = 40, fire = 70, acid = 50)
-	self_weight = 30
+	armor = list(melee = 55, bullet = 55, laser = 20, energy = 15, bomb = 40, bio =100, rad = 100, fire = 100, acid = 100)
+	self_weight = 18
 
 /obj/item/clothing/suit/armor/f13/power_armor/t51b
 	name = "T-51b power armor"
 	desc = "A mass-produced pinnacle of pre-War engineering.<br>Developed in the laboratories of the West Tek Research Facility, the T-51b was deployed at the end of the Anchorage Reclamation, and by January 2077, the armor had become standard issue for American soldiers in the Army's Mechanized Cavalry Regiments."
 	icon_state = "t51bpowerarmor"
 	item_state = "t51bpowerarmor"
-	armor = list(melee = 70, bullet = 70, laser = 70, energy = 70, bomb = 60, bio = 100, rad = 60, fire = 60, acid = 60)
-	self_weight = 25
+	armor = list(melee = 65, bullet = 65, laser = 25, energy = 20, bomb = 45, bio = 100, rad = 100, fire = 100, acid = 100)
+	self_weight = 18
 
 /obj/item/clothing/suit/armor/f13/power_armor/t60
 	name = "T-60 power armor"
 	desc = "Developed in early 2077 after the Anchorage Reclamation, the T-60 series of power armor was designed to eventually replace the T-51b power armor as the pinnacle of powered armor technology in the U.S. military arsenal.<br>Incorporating design elements from the earlier T-45, the T-60 was deployed domestically among U.S. Army units just prior to the dropping of the bombs."
 	icon_state = "t60powerarmor"
 	item_state = "t60powerarmor"
-	armor = list(melee = 80, bullet = 80, laser = 80, energy = 80, bomb = 60, bio = 100, rad = 75, fire = 70, acid = 70)
-	self_weight = 25
+	armor = list(melee = 65, bullet = 65, laser = 35, energy = 25, bomb = 45, bio = 100, rad = 100, fire = 100, acid = 100)
+	self_weight = 18
 
 // enclave armors
 
 /obj/item/clothing/suit/armor/f13/power_armor/advanced
-	name = "advanced power armor mark I"
+	name = "advanced power armor Mk. I 'Bugeye'"
 	desc = "An advanced suit of armor typically used by the Enclave.<br>It is composed of lightweight metal alloys, reinforced with ceramic castings at key stress points.<br>Additionally, like the T-51b power armor, it includes a recycling system that can convert human waste into drinkable water, and an air conditioning system for it's user's comfort."
 	icon_state = "advanced"
 	item_state = "advanced"
-	armor = list(melee = 60, bullet = 60, laser = 60, energy = 60, bomb = 60, bio = 100, rad = 60, fire = 60, acid = 60)
-	self_weight = 20
+	armor = list(melee = 70, bullet = 70, laser = 50, energy = 45, bomb = 45, bio = 100, rad = 100, fire = 100, acid = 100)
+	self_weight = 18
 
 /obj/item/clothing/suit/armor/f13/power_armor/superadvanced
-	name = "advanced power armor mark II"
+	name = "advanced power armor Mk. II 'Bugeye'"
 	desc = "An improved model of advanced power armor used exclusively by the Enclave military forces, developed after the Great War.<br>Like its older brother, the standard advanced power armor, it's matte black with a menacing appearance, but with a few significant differences - it appears to be composed entirely of lightweight ceramic composites rather than the usual combination of metal and ceramic plates.<br>Additionally, like the T-51b power armor, it includes a recycling system that can convert human waste into drinkable water, and an air conditioning system for it's user's comfort."
 	icon_state = "superadvanced"
 	item_state = "superadvanced"
-	armor = list(melee = 70, bullet = 70, laser = 70, energy = 70, bomb = 70, bio = 100, rad = 80, fire = 80, acid = 80)
-	self_weight = 13
+	armor = list(melee = 75, bullet = 75, laser = 55, energy = 55, bomb = 55, bio = 100, rad = 100, fire = 100, acid = 100)
+	self_weight = 12
 
 /obj/item/clothing/suit/armor/f13/power_armor/shocktrooper
-	name = "hellfire power armor"
+	name = "advanced power armor Mk. III 'Black Devil'" //for the sake of lore consistency, taking both bethesda and black isle/interplays versions and just saying the one in fo3 is the mark 3, with mark 2 being last of the first apa iterations. also fixed the name because hellfire is the one from broken steel, this one is the black devil/standard apa from fo3. Nicknames have also been added to the armors.
 	desc = "A \"Black Devil\" power armor - a high-end model used exclusively by the Enclave's Department of the Army and developed after the Great War and the destruction of the Enclave Oil Rig in 2241.<br>It is composed entirely of lightweight composites rather than the usual combination of metal and composite plates found on the previous designations of advanced power armor, the mark I and II."
 	icon_state = "shocktrooper"
 	item_state = "shocktrooper"
-	armor = list(melee = 80, bullet = 80, laser = 70, energy = 70, bomb = 80, bio = 100, rad = 90, fire = 80, acid = 80)
-	self_weight = 12
+	armor = list(melee = 95, bullet = 95, laser = 65, energy = 60, bomb = 60, bio = 100, rad = 100, fire = 100, acid = 100)
+	self_weight = 15
 
 /obj/item/clothing/suit/armor/f13/power_armor/tesla
-	name = "tesla power armor"
+	name = "advanced tesla power armor Mk. I 'Bugeye'"
 	desc = "A variant of the Enclave's advanced power armor Mk I, jury-rigged with a Tesla device that is capable of dispersing a large percentage of the damage done by directed-energy attacks.<br>As it's made of complex composite materials designed to block most of energy damage - it's notably weaker against kinetic impacts."
 	icon_state = "tesla"
 	item_state = "tesla"
-	armor = list(melee = 55, bullet = 55, laser = 85, energy = 85, bomb = 40, bio = 100, rad = 80, fire = 80, acid = 80)
+	armor = list(melee = 55, bullet = 55, laser = 95, energy = 95, bomb = 45, bio = 100, rad = 100, fire = 100, acid = 100)
 	self_weight = 15
 
 /obj/item/clothing/suit/armor/f13/power_armor/badmin
-	name = "advanced power armor Mk III"
-	desc = "A group of Enclave mad scientists lead by Administrator Badmin, have spent a decade working on the super weapon you see in front of you."
+	name = "advanced power armor Mk IV 'Hellfire'"
+	desc = "Enclave Hellfire armor is a heat-resistant power armor worn by high level Enclave soldiers and the specialized, elite Enclave Hellfire troopers."
 	icon_state = "badmin"
 	item_state = "badmin"
-	armor = list(melee = 99, bullet = 99, laser = 90, energy = 90, bomb = 90, bio = 100, rad = 100, fire = 90, acid = 100) //Burn baby, burn!
-	self_weight = 1
+	armor = list(melee = 95, bullet = 95, laser = 70, energy = 70, bomb = 45, bio = 100, rad = 100, fire = 100, acid = 100) //Burn baby, burn!
+	self_weight = 18
 
 //Knights of the Apocalypse
 

--- a/code/modules/fallout/obj/clothing/suits/armor.dm
+++ b/code/modules/fallout/obj/clothing/suits/armor.dm
@@ -393,7 +393,7 @@
 	strip_delay = 600 //strip and equip timers increased, should discourage messing around with power armour bodies honestly, power armour generally requires a team of technicians to outfit the wearer into the suit, rather than just being an easily deployed suit of combat armor.
 	special_defence = PREVENTDISMEMBER
 
-/obj/item/clothing/suit/armor/f13/power_armor/mob_can_equip(mob/user, slot)
+/obj/item/clothing/suit/armor/f13/power_armor/mob_can_equip(mob/user, slot) //THIS PART NEEDS FIXING. CODE CURRENTLY DOES NOT WORK NOR DO FACTIONS HAVE MARTIAL ART APPLIED TO THEM TO PASS THIS CHECK ONCE IT DOES WORK.
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		if(!H.martial_art && H.martial_art.name != "Power Armor Training" && slot == slot_wear_suit)

--- a/code/modules/fallout/obj/clothing/suits/armor.dm
+++ b/code/modules/fallout/obj/clothing/suits/armor.dm
@@ -463,7 +463,7 @@
 	self_weight = 15
 
 /obj/item/clothing/suit/armor/f13/power_armor/badmin
-	name = "advanced power armor Mk IV 'Hellfire'"
+	name = "advanced power armor Mk. IV 'Hellfire'"
 	desc = "Enclave Hellfire armor is a heat-resistant power armor worn by high level Enclave soldiers and the specialized, elite Enclave Hellfire troopers."
 	icon_state = "badmin"
 	item_state = "badmin"

--- a/code/modules/fallout/obj/clothing/suits/armor.dm
+++ b/code/modules/fallout/obj/clothing/suits/armor.dm
@@ -339,7 +339,7 @@
 	strip_delay = 100
 	self_weight = 40
 	slowdown = 1
-	armor = list(melee = 70, bullet = 70, laser = 5, energy = 5, bomb = 15, bio = 100, rad = 100, fire = 100, acid = 100) //These changes aren't necessarily realistic as no servomotors = less effective at disappating oncoming force but should serve to give NCR heavy troopers an actual role in combat. Should be far better suited towards a defensive playstyle against ballistic weapons.
+	armor = list(melee = 70, bullet = 70, laser = 30, energy = 30, bomb = 15, bio = 100, rad = 100, fire = 100, acid = 100) //These changes aren't necessarily realistic as no servomotors = less effective at disappating oncoming force but should serve to give NCR heavy troopers an actual role in combat. Should be far better suited towards a defensive playstyle against ballistic weapons.
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 
 /obj/item/clothing/suit/armor/f13/power_armor/sierra

--- a/code/modules/fallout/obj/clothing/suits/armor.dm
+++ b/code/modules/fallout/obj/clothing/suits/armor.dm
@@ -348,7 +348,7 @@
 	icon_state = "sierra"
 	item_state = "sierra"
 	armor = list(melee = 55, bullet = 55, laser = 20, energy = 15, bomb = 25, bio = 100, rad = 100, fire = 100, acid = 100)
-	self_weight = 25 //weight adjusted and general behaviour put more in line with regular power armour since sierra power armour is meant to have its servomotors still installed and used by captains that have been trained to use power armour
+	self_weight = 18 //weight adjusted and general behaviour put more in line with regular power armour since sierra power armour is meant to have its servomotors still installed and used by captains that have been trained to use power armour
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	
 // ncr armor end

--- a/code/modules/fallout/obj/clothing/suits/armor.dm
+++ b/code/modules/fallout/obj/clothing/suits/armor.dm
@@ -431,7 +431,7 @@
 // enclave armors
 
 /obj/item/clothing/suit/armor/f13/power_armor/advanced
-	name = "advanced power armor Mk. I 'Bugeye'"
+	name = "advanced power armor Mk. I 'Bugman'"
 	desc = "An advanced suit of armor typically used by the Enclave.<br>It is composed of lightweight metal alloys, reinforced with ceramic castings at key stress points.<br>Additionally, like the T-51b power armor, it includes a recycling system that can convert human waste into drinkable water, and an air conditioning system for it's user's comfort."
 	icon_state = "advanced"
 	item_state = "advanced"
@@ -439,7 +439,7 @@
 	self_weight = 18
 
 /obj/item/clothing/suit/armor/f13/power_armor/superadvanced
-	name = "advanced power armor Mk. II 'Bugeye'"
+	name = "advanced power armor Mk. II 'Bugman'"
 	desc = "An improved model of advanced power armor used exclusively by the Enclave military forces, developed after the Great War.<br>Like its older brother, the standard advanced power armor, it's matte black with a menacing appearance, but with a few significant differences - it appears to be composed entirely of lightweight ceramic composites rather than the usual combination of metal and ceramic plates.<br>Additionally, like the T-51b power armor, it includes a recycling system that can convert human waste into drinkable water, and an air conditioning system for it's user's comfort."
 	icon_state = "superadvanced"
 	item_state = "superadvanced"
@@ -455,7 +455,7 @@
 	self_weight = 15
 
 /obj/item/clothing/suit/armor/f13/power_armor/tesla
-	name = "advanced tesla power armor Mk. I 'Bugeye'"
+	name = "advanced tesla power armor Mk. I 'Bugman'"
 	desc = "A variant of the Enclave's advanced power armor Mk I, jury-rigged with a Tesla device that is capable of dispersing a large percentage of the damage done by directed-energy attacks.<br>As it's made of complex composite materials designed to block most of energy damage - it's notably weaker against kinetic impacts."
 	icon_state = "tesla"
 	item_state = "tesla"

--- a/code/modules/fallout/obj/clothing/suits/miscellaneous.dm
+++ b/code/modules/fallout/obj/clothing/suits/miscellaneous.dm
@@ -42,7 +42,7 @@
 	item_state = "hostrench"
 	body_parts_covered = CHEST|ARMS
 	self_weight = 15
-	armor = list(melee = 20, bullet = 20, laser = 10, energy = 10, bomb = 20, bio = 0, rad = 0, fire = 20, acid = 0)
+	armor = list(melee = 20, bullet = 10, laser = 10, energy = 10, bomb = 20, bio = 0, rad = 0, fire = 20, acid = 0)
 	allowed = list(/obj/item/weapon/pen,/obj/item/weapon/paper,/obj/item/weapon/stamp,/obj/item/weapon/reagent_containers/food/drinks/flask,/obj/item/weapon/melee,/obj/item/weapon/storage/box/matches,/obj/item/weapon/lighter,/obj/item/clothing/mask/cigarette,/obj/item/weapon/storage/fancy/cigarettes,/obj/item/device/flashlight,/obj/item/weapon/gun/energy,/obj/item/weapon/gun,/obj/item/ammo_box,/obj/item/ammo_casing)
 
 /obj/item/clothing/suit/f13/cowboybvest //Originally cowboy stuff by Nienhaus
@@ -66,14 +66,14 @@
 	item_state = "hostrench"
 	body_parts_covered = CHEST|ARMS
 	self_weight = 2
-	armor = list(melee = 25, bullet = 30, laser = 30, energy = 30, bomb = 30, bio = 0, rad = 30, fire = 20, acid = 25)
+	armor = list(melee = 15, bullet = 20, laser = 10, energy = 10, bomb = 10, bio = 0, rad = 5, fire = 10, acid = 15)
 	allowed = list(/obj/item/weapon/pen,/obj/item/weapon/paper,/obj/item/weapon/stamp,/obj/item/weapon/reagent_containers/food/drinks/flask,/obj/item/weapon/melee,/obj/item/weapon/storage/box/matches,/obj/item/weapon/lighter,/obj/item/clothing/mask/cigarette,/obj/item/weapon/storage/fancy/cigarettes,/obj/item/device/flashlight,/obj/item/weapon/gun,/obj/item/ammo_box,/obj/item/ammo_casing)
 
 /obj/item/clothing/suit/f13/mfp/raider //"Offbeat" is actually a quote from Mad Max said by Max himself.
 	name = "offbeat jacket"
 	desc = "A black leather jacket with a single metal shoulder pad on the right side.<br>The right sleeve was obviously ripped or cut away.<br>It looks like it was originally a piece of a Main Force Patrol uniform."
 	icon_state = "mfp_raider"
-	armor = list(melee = 30, bullet = 40, laser = 40, energy = 35, bomb = 35, bio = 20, rad = 40, fire = 40, acid = 30)
+	armor = list(melee = 30, bullet = 20, laser = 10, energy = 25, bomb = 25, bio = 20, rad = 40, fire = 40, acid = 30)
 
 /obj/item/clothing/suit/f13/rolandcoat
 	name = "gaucho duster"
@@ -82,7 +82,7 @@
 	item_state = "rolandcoat"
 	body_parts_covered = CHEST|ARMS
 	self_weight = 2
-	armor = list(melee = 25, bullet = 30, laser = 30, energy = 30, bomb = 30, bio = 0, rad = 100, fire = 100, acid = 100)
+	armor = list(melee = 25, bullet = 15, laser = 15, energy = 15, bomb = 25, bio = 35, rad = 35, fire = 35, acid = 35)
 	allowed = list(/obj/item/weapon/pen,/obj/item/weapon/paper,/obj/item/weapon/stamp,/obj/item/weapon/reagent_containers/food/drinks/flask,/obj/item/weapon/melee,/obj/item/weapon/storage/box/matches,/obj/item/weapon/lighter,/obj/item/clothing/mask/cigarette,/obj/item/weapon/storage/fancy/cigarettes,/obj/item/device/flashlight)
 
 /obj/item/clothing/suit/rolandcoatremake
@@ -92,7 +92,7 @@
 	item_state = "rolandcoatremake"
 	body_parts_covered = CHEST|ARMS
 	self_weight = 2
-	armor = list(melee = 35, bullet = 50, laser = 40, energy = 50, bomb = 30, bio = 0, rad = 100, fire = 100, acid = 100)
+	armor = list(melee = 25, bullet = 15, laser = 15, energy = 15, bomb = 25, bio = 35, rad = 35, fire = 35, acid = 35)
 	allowed = list(/obj/item/weapon/pen,/obj/item/weapon/paper,/obj/item/weapon/stamp,/obj/item/weapon/reagent_containers/food/drinks/flask,/obj/item/weapon/melee,/obj/item/weapon/storage/box/matches,/obj/item/weapon/lighter,/obj/item/clothing/mask/cigarette,/obj/item/weapon/storage/fancy/cigarettes,/obj/item/device/flashlight)
 
 /obj/item/clothing/suit/loomiscoat
@@ -103,7 +103,7 @@
 	body_parts_covered = CHEST|ARMS
 	self_weight = 2
 	pockets = /obj/item/weapon/storage/internal/pocket/big/coat
-	armor = list(melee = 35, bullet = 50, laser = 40, energy = 50, bomb = 30, bio = 0, rad = 100, fire = 100, acid = 100)
+	armor = list(melee = 25, bullet = 10, laser = 15, energy = 15, bomb = 25, bio = 35, rad = 35, fire = 35, acid = 35)
 	allowed = list(/obj/item/weapon/pen,/obj/item/weapon/paper,/obj/item/weapon/stamp,/obj/item/weapon/reagent_containers/food/drinks/flask,/obj/item/weapon/melee,/obj/item/weapon/storage/box/matches,/obj/item/weapon/lighter,/obj/item/clothing/mask/cigarette,/obj/item/weapon/storage/fancy/cigarettes)
 
 /obj/item/clothing/suit/stokercoat
@@ -114,7 +114,7 @@
 	body_parts_covered = CHEST|ARMS
 	self_weight = 2
 	pockets = /obj/item/weapon/storage/internal/pocket/big/coat
-	armor = list(melee = 35, bullet = 50, laser = 40, energy = 50, bomb = 30, bio = 0, rad = 100, fire = 100, acid = 100)
+	armor = list(melee = 25, bullet = 10, laser = 15, energy = 15, bomb = 25, bio = 35, rad = 35, fire = 35, acid = 35)
 	allowed = list(/obj/item/weapon/pen,/obj/item/weapon/paper,/obj/item/weapon/stamp,/obj/item/weapon/reagent_containers/food/drinks/flask,/obj/item/weapon/melee,/obj/item/weapon/storage/box/matches,/obj/item/weapon/lighter,/obj/item/clothing/mask/cigarette,/obj/item/weapon/storage/fancy/cigarettes)
 
 /obj/item/clothing/suit/communitycoat
@@ -125,7 +125,7 @@
 	body_parts_covered = CHEST|ARMS
 	self_weight = 2
 	pockets = /obj/item/weapon/storage/internal/pocket/big/coat
-	armor = list(melee = 35, bullet = 50, laser = 40, energy = 50, bomb = 30, bio = 0, rad = 100, fire = 100, acid = 100)
+	armor = list(melee = 25, bullet = 10, laser = 15, energy = 15, bomb = 25, bio = 35, rad = 35, fire = 35, acid = 35)
 	allowed = list(/obj/item/weapon/pen,/obj/item/weapon/paper,/obj/item/weapon/stamp,/obj/item/weapon/reagent_containers/food/drinks/flask,/obj/item/weapon/melee,/obj/item/weapon/storage/box/matches,/obj/item/weapon/lighter,/obj/item/clothing/mask/cigarette,/obj/item/weapon/storage/fancy/cigarettes)
 
 /obj/item/clothing/suit/belmontcoat
@@ -136,7 +136,7 @@
 	body_parts_covered = CHEST|ARMS
 	self_weight = 2
 	pockets = /obj/item/weapon/storage/internal/pocket/big/coat
-	armor = list(melee = 35, bullet = 50, laser = 40, energy = 50, bomb = 30, bio = 0, rad = 100, fire = 100, acid = 100)
+	armor = list(melee = 25, bullet = 10, laser = 15, energy = 15, bomb = 25, bio = 35, rad = 35, fire = 35, acid = 35)
 	allowed = list(/obj/item/weapon/pen,/obj/item/weapon/paper,/obj/item/weapon/stamp,/obj/item/weapon/reagent_containers/food/drinks/flask,/obj/item/weapon/melee,/obj/item/weapon/storage/box/matches,/obj/item/weapon/lighter,/obj/item/clothing/mask/cigarette,/obj/item/weapon/storage/fancy/cigarettes)
 
 /obj/item/clothing/suit/communitycoatalt
@@ -147,7 +147,7 @@
 	body_parts_covered = CHEST|ARMS
 	self_weight = 2
 	pockets = /obj/item/weapon/storage/internal/pocket/big/coat
-	armor = list(melee = 35, bullet = 50, laser = 40, energy = 50, bomb = 30, bio = 0, rad = 100, fire = 100, acid = 100)
+	armor = list(melee = 25, bullet = 10, laser = 15, energy = 15, bomb = 25, bio = 35, rad = 35, fire = 35, acid = 35)
 	allowed = list(/obj/item/weapon/pen,/obj/item/weapon/paper,/obj/item/weapon/stamp,/obj/item/weapon/reagent_containers/food/drinks/flask,/obj/item/weapon/melee,/obj/item/weapon/storage/box/matches,/obj/item/weapon/lighter,/obj/item/clothing/mask/cigarette,/obj/item/weapon/storage/fancy/cigarettes)
 
 /obj/item/clothing/suit/belmontcoatalt
@@ -158,7 +158,7 @@
 	body_parts_covered = CHEST|ARMS
 	self_weight = 2
 	pockets = /obj/item/weapon/storage/internal/pocket/big/coat
-	armor = list(melee = 35, bullet = 50, laser = 40, energy = 50, bomb = 30, bio = 0, rad = 100, fire = 100, acid = 100)
+	armor = list(melee = 25, bullet = 25, laser = 15, energy = 15, bomb = 15, bio = 25, rad = 25, fire = 25, acid = 25)
 	allowed = list(/obj/item/weapon/pen,/obj/item/weapon/paper,/obj/item/weapon/stamp,/obj/item/weapon/reagent_containers/food/drinks/flask,/obj/item/weapon/storage/box/matches,/obj/item/weapon/lighter,/obj/item/clothing/mask/cigarette,/obj/item/weapon/storage/fancy/cigarettes)
 
 /obj/item/clothing/suit/juliuscoat
@@ -169,7 +169,7 @@
 	body_parts_covered = CHEST|ARMS
 	self_weight = 2
 	pockets = /obj/item/weapon/storage/internal/pocket/big/coat
-	armor = list(melee = 35, bullet = 50, laser = 40, energy = 50, bomb = 30, bio = 0, rad = 100, fire = 100, acid = 100)
+	armor = list(melee = 25, bullet = 25, laser = 15, energy = 15, bomb = 15, bio = 25, rad = 25, fire = 25, acid = 25)
 	allowed = list(/obj/item/weapon/pen,/obj/item/weapon/paper,/obj/item/weapon/stamp,/obj/item/weapon/reagent_containers/food/drinks/flask,/obj/item/weapon/storage/box/matches,/obj/item/weapon/lighter,/obj/item/clothing/mask/cigarette,/obj/item/weapon/storage/fancy/cigarettes)
 
 /obj/item/clothing/suit/cruzcoat
@@ -180,7 +180,7 @@
 	body_parts_covered = CHEST|ARMS
 	self_weight = 2
 	pockets = /obj/item/weapon/storage/internal/pocket/big/coat
-	armor = list(melee = 35, bullet = 50, laser = 40, energy = 50, bomb = 30, bio = 0, rad = 100, fire = 100, acid = 100)
+	armor = list(melee = 25, bullet = 25, laser = 15, energy = 15, bomb = 15, bio = 25, rad = 25, fire = 25, acid = 25)
 	allowed = list(/obj/item/weapon/pen,/obj/item/weapon/paper,/obj/item/weapon/stamp,/obj/item/weapon/reagent_containers/food/drinks/flask,/obj/item/weapon/storage/box/matches,/obj/item/weapon/lighter,/obj/item/clothing/mask/cigarette,/obj/item/weapon/storage/fancy/cigarettes)
 
 /obj/item/clothing/suit/vampirecoat
@@ -191,7 +191,7 @@
 	body_parts_covered = CHEST|ARMS
 	self_weight = 2
 	pockets = /obj/item/weapon/storage/internal/pocket/big/coat
-	armor = list(melee = 35, bullet = 50, laser = 40, energy = 50, bomb = 30, bio = 0, rad = 100, fire = 100, acid = 100)
+	armor = list(melee = 25, bullet = 25, laser = 15, energy = 15, bomb = 15, bio = 25, rad = 25, fire = 25, acid = 25)
 	allowed = list(/obj/item/weapon/pen,/obj/item/weapon/paper,/obj/item/weapon/stamp,/obj/item/weapon/reagent_containers/food/drinks/flask,/obj/item/weapon/melee,/obj/item/weapon/storage/box/matches,/obj/item/weapon/lighter,/obj/item/clothing/mask/cigarette,/obj/item/weapon/storage/fancy/cigarettes)
 
 /obj/item/clothing/suit/wolfjacket
@@ -202,7 +202,7 @@
 	body_parts_covered = CHEST|ARMS
 	self_weight = 2
 	pockets = /obj/item/weapon/storage/internal/pocket/big/coat
-	armor = list(melee = 35, bullet = 50, laser = 40, energy = 50, bomb = 30, bio = 0, rad = 100, fire = 100, acid = 100)
+	armor = list(melee = 25, bullet = 25, laser = 15, energy = 15, bomb = 15, bio = 25, rad = 25, fire = 25, acid = 25)
 	allowed = list(/obj/item/weapon/pen,/obj/item/weapon/paper,/obj/item/weapon/stamp,/obj/item/weapon/reagent_containers/food/drinks/flask,/obj/item/weapon/melee,/obj/item/weapon/storage/box/matches,/obj/item/weapon/lighter,/obj/item/clothing/mask/cigarette,/obj/item/weapon/storage/fancy/cigarettes)
 
 /obj/item/clothing/suit/harryjacket
@@ -213,7 +213,7 @@
 	body_parts_covered = CHEST|ARMS
 	self_weight = 2
 	pockets = /obj/item/weapon/storage/internal/pocket/big/coat
-	armor = list(melee = 35, bullet = 50, laser = 40, energy = 50, bomb = 30, bio = 0, rad = 100, fire = 100, acid = 100)
+	armor = list(melee = 25, bullet = 25, laser = 15, energy = 15, bomb = 15, bio = 25, rad = 25, fire = 25, acid = 25)
 	allowed = list(/obj/item/weapon/pen,/obj/item/weapon/paper,/obj/item/weapon/stamp,/obj/item/weapon/reagent_containers/food/drinks/flask,/obj/item/weapon/melee,/obj/item/weapon/storage/box/matches,/obj/item/weapon/lighter,/obj/item/clothing/mask/cigarette,/obj/item/weapon/storage/fancy/cigarettes)
 
 /obj/item/clothing/suit/gatjacket
@@ -224,7 +224,7 @@
 	body_parts_covered = CHEST|ARMS
 	self_weight = 2
 	pockets = /obj/item/weapon/storage/internal/pocket/big/coat
-	armor = list(melee = 35, bullet = 50, laser = 40, energy = 50, bomb = 30, bio = 0, rad = 100, fire = 100, acid = 100)
+	armor = list(melee = 25, bullet = 25, laser = 15, energy = 15, bomb = 15, bio = 25, rad = 25, fire = 25, acid = 25)
 	allowed = list(/obj/item/weapon/pen,/obj/item/weapon/paper,/obj/item/weapon/stamp,/obj/item/weapon/reagent_containers/food/drinks/flask,/obj/item/weapon/melee,/obj/item/weapon/storage/box/matches,/obj/item/weapon/lighter,/obj/item/clothing/mask/cigarette,/obj/item/weapon/storage/fancy/cigarettes)
 
 /obj/item/clothing/suit/rolandcoatthree
@@ -234,7 +234,7 @@
 	item_state = "rolandcoatthree"
 	body_parts_covered = CHEST|ARMS
 	self_weight = 2
-	armor = list(melee = 35, bullet = 50, laser = 40, energy = 50, bomb = 30, bio = 0, rad = 100, fire = 100, acid = 100)
+	armor = list(melee = 25, bullet = 15, laser = 15, energy = 15, bomb = 25, bio = 35, rad = 35, fire = 35, acid = 35)
 	allowed = list(/obj/item/weapon/pen,/obj/item/weapon/paper,/obj/item/weapon/stamp,/obj/item/weapon/reagent_containers/food/drinks/flask,/obj/item/weapon/melee,/obj/item/weapon/storage/box/matches,/obj/item/weapon/lighter,/obj/item/clothing/mask/cigarette,/obj/item/weapon/storage/fancy/cigarettes,/obj/item/device/flashlight)
 
 /obj/item/clothing/suit/gunslingercoat
@@ -244,7 +244,7 @@
 	item_state = "gunslingercoat"
 	body_parts_covered = CHEST|ARMS
 	self_weight = 2
-	armor = list(melee = 35, bullet = 50, laser = 40, energy = 50, bomb = 30, bio = 0, rad = 100, fire = 100, acid = 100)
+	armor = list(melee = 25, bullet = 15, laser = 15, energy = 15, bomb = 25, bio = 35, rad = 35, fire = 35, acid = 35)
 	allowed = list(/obj/item/weapon/pen,/obj/item/weapon/paper,/obj/item/weapon/stamp,/obj/item/weapon/reagent_containers/food/drinks/flask,/obj/item/weapon/melee,/obj/item/weapon/storage/box/matches,/obj/item/weapon/lighter,/obj/item/clothing/mask/cigarette,/obj/item/weapon/storage/fancy/cigarettes,/obj/item/device/flashlight)
 
 /obj/item/clothing/suit/johncowboycoat
@@ -254,7 +254,7 @@
 	item_state = "johncowboycoat"
 	body_parts_covered = CHEST|ARMS
 	self_weight = 2
-	armor = list(melee = 35, bullet = 50, laser = 40, energy = 50, bomb = 30, bio = 0, rad = 100, fire = 100, acid = 100)
+	armor = list(melee = 25, bullet = 15, laser = 15, energy = 15, bomb = 25, bio = 35, rad = 35, fire = 35, acid = 35)
 	allowed = list(/obj/item/weapon/pen,/obj/item/weapon/paper,/obj/item/weapon/stamp,/obj/item/weapon/reagent_containers/food/drinks/flask,/obj/item/weapon/melee,/obj/item/weapon/storage/box/matches,/obj/item/weapon/lighter,/obj/item/clothing/mask/cigarette,/obj/item/weapon/storage/fancy/cigarettes,/obj/item/device/flashlight)
 
 /obj/item/clothing/suit/rolandcloak
@@ -264,7 +264,7 @@
 	item_state = "rolandcloak"
 	body_parts_covered = CHEST|ARMS
 	self_weight = 2
-	armor = list(melee = 35, bullet = 50, laser = 40, energy = 50, bomb = 30, bio = 0, rad = 100, fire = 100, acid = 100)
+	armor = list(melee = 25, bullet = 15, laser = 15, energy = 15, bomb = 25, bio = 35, rad = 35, fire = 35, acid = 35)
 	allowed = list(/obj/item/weapon/pen,/obj/item/weapon/paper,/obj/item/weapon/stamp,/obj/item/weapon/reagent_containers/food/drinks/flask,/obj/item/weapon/melee,/obj/item/weapon/storage/box/matches,/obj/item/weapon/lighter,/obj/item/clothing/mask/cigarette,/obj/item/weapon/storage/fancy/cigarettes,/obj/item/device/flashlight)
 
 /obj/item/clothing/suit/rolandponcho
@@ -274,7 +274,7 @@
 	item_state = "rolandponcho"
 	body_parts_covered = CHEST|ARMS
 	self_weight = 2
-	armor = list(melee = 25, bullet = 30, laser = 30, energy = 30, bomb = 30, bio = 0, rad = 100, fire = 100, acid = 100)
+	armor = list(melee = 25, bullet = 15, laser = 15, energy = 15, bomb = 25, bio = 35, rad = 35, fire = 35, acid = 35)
 	allowed = list(/obj/item/weapon/pen,/obj/item/weapon/paper,/obj/item/weapon/stamp,/obj/item/weapon/reagent_containers/food/drinks/flask,/obj/item/weapon/melee,/obj/item/weapon/storage/box/matches,/obj/item/weapon/lighter,/obj/item/clothing/mask/cigarette,/obj/item/weapon/storage/fancy/cigarettes,/obj/item/device/flashlight,/obj/item/weapon/gun,/obj/item/ammo_box,/obj/item/ammo_casing)
 
 /obj/item/clothing/suit/terminatorjacket
@@ -284,7 +284,7 @@
 	item_state = "terminatorjacket"
 	body_parts_covered = CHEST|ARMS
 	self_weight = 2
-	armor = list(melee = 25, bullet = 30, laser = 30, energy = 30, bomb = 30, bio = 0, rad = 100, fire = 100, acid = 100)
+	armor = list(melee = 25, bullet = 15, laser = 15, energy = 15, bomb = 25, bio = 35, rad = 35, fire = 35, acid = 35)
 	allowed = list(/obj/item/weapon/pen,/obj/item/weapon/paper,/obj/item/weapon/stamp,/obj/item/weapon/reagent_containers/food/drinks/flask,/obj/item/weapon/melee,/obj/item/weapon/storage/box/matches,/obj/item/weapon/lighter,/obj/item/clothing/mask/cigarette,/obj/item/weapon/storage/fancy/cigarettes,/obj/item/device/flashlight,/obj/item/weapon/gun,/obj/item/ammo_box,/obj/item/ammo_casing)
 
 /obj/item/clothing/suit/f13/mfp/johnjacket
@@ -300,7 +300,7 @@
 	item_state = "suit-command"
 	body_parts_covered = CHEST|GROIN
 	self_weight = 5
-	armor = list(melee = 20, bullet = 20, laser = 10, energy = 10, bomb = 20, bio = 0, rad = 0, fire = 10, acid = 0)
+	armor = list(melee = 25, bullet = 15, laser = 15, energy = 15, bomb = 25, bio = 35, rad = 35, fire = 35, acid = 35)
 	allowed = list(/obj/item/weapon/pen,/obj/item/weapon/paper,/obj/item/weapon/stamp,/obj/item/weapon/reagent_containers/food/drinks/flask,/obj/item/weapon/melee,/obj/item/weapon/storage/box/matches,/obj/item/weapon/lighter,/obj/item/clothing/mask/cigarette,/obj/item/weapon/storage/fancy/cigarettes,/obj/item/device/flashlight,/obj/item/weapon/gun,/obj/item/ammo_box,/obj/item/ammo_casing)
 
 /obj/item/clothing/suit/f13/veteran
@@ -310,7 +310,7 @@
 	item_state = "suit-command"
 	body_parts_covered = CHEST|GROIN
 	self_weight = 6
-	armor = list(melee = 20, bullet = 20, laser = 10, energy = 10, bomb = 20, bio = 0, rad = 0, fire = 10, acid = 0)
+	armor = list(melee = 25, bullet = 25, laser = 15, energy = 15, bomb = 25, bio = 35, rad = 35, fire = 35, acid = 35)
 	allowed = list(/obj/item/weapon/pen,/obj/item/weapon/paper,/obj/item/weapon/stamp,/obj/item/weapon/reagent_containers/food/drinks/flask,/obj/item/weapon/melee,/obj/item/weapon/storage/box/matches,/obj/item/weapon/lighter,/obj/item/clothing/mask/cigarette,/obj/item/weapon/storage/fancy/cigarettes,/obj/item/device/flashlight,/obj/item/weapon/gun,/obj/item/ammo_box,/obj/item/ammo_casing)
 
 /obj/item/clothing/suit/f13/duster
@@ -320,7 +320,7 @@
 	item_state = "det_suit"
 	body_parts_covered = CHEST|LEGS|FEET|ARMS
 	self_weight = 7
-	armor = list(melee = 30, bullet = 25, laser = 20, energy = 20, bomb = 20, bio = 10, rad = 20, fire = 20, acid = 20)
+	armor = list(melee = 25, bullet = 25, laser = 15, energy = 15, bomb = 25, bio = 35, rad = 35, fire = 35, acid = 35)
 	allowed = list(/obj/item/weapon/pen,/obj/item/weapon/paper,/obj/item/weapon/stamp,/obj/item/weapon/reagent_containers/food/drinks/flask,/obj/item/weapon/melee,/obj/item/weapon/storage/box/matches,/obj/item/weapon/lighter,/obj/item/clothing/mask/cigarette,/obj/item/weapon/storage/fancy/cigarettes,/obj/item/device/flashlight,/obj/item/weapon/gun,/obj/item/ammo_box,/obj/item/ammo_casing)
 
 /obj/item/clothing/suit/f13/sheriff
@@ -340,7 +340,7 @@
 	item_state = "autumn"
 	self_weight = 10
 	body_parts_covered = CHEST|LEGS|FEET|ARMS
-	armor = list(melee = 50, bullet = 45, laser = 40, energy = 40, bomb = 20, bio = 20, rad = 50, fire = 30, acid = 30) //Reference to colonel not dying from radiation where anyone else dies.
+	armor = list(melee = 40, bullet = 35, laser = 40, energy = 40, bomb = 20, bio = 20, rad = 50, fire = 30, acid = 30) //Reference to colonel not dying from radiation where anyone else dies.
 	allowed = list(/obj/item/weapon/pen,/obj/item/weapon/paper,/obj/item/weapon/stamp,/obj/item/weapon/reagent_containers/food/drinks/flask,/obj/item/weapon/melee,/obj/item/weapon/storage/box/matches,/obj/item/weapon/lighter,/obj/item/clothing/mask/cigarette,/obj/item/weapon/storage/fancy/cigarettes,/obj/item/device/flashlight,/obj/item/weapon/gun,/obj/item/ammo_box,/obj/item/ammo_casing)
 
 /obj/item/clothing/suit/f13/hubologist

--- a/code/modules/fallout/obj/clothing/under/miscellaneous.dm
+++ b/code/modules/fallout/obj/clothing/under/miscellaneous.dm
@@ -443,7 +443,7 @@
 	item_state = "bl_suit"
 	item_color = "enclave_o"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	armor = list(melee = 25, bullet = 20, laser = 20, energy = 20, bomb = 10, bio = 10, rad = 20, fire = 15, acid = 15)
+	armor = list(melee = 15, bullet = 25, laser = 15, energy = 10, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
 	can_adjust = 0
 	self_weight = 3
 
@@ -454,7 +454,7 @@
 	item_state = "lb_suit"
 	item_color = "ncr_o"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	armor = list(melee = 20, bullet = 10, laser = 10, energy = 10, bomb = 10, bio = 10, rad = 10, fire = 10, acid = 10)
+	armor = list(melee = 10, bullet = 15, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
 	can_adjust = 0
 	self_weight = 3
 
@@ -496,7 +496,7 @@
 	item_color = "recon"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS|HEAD
 	flags_inv = HIDEHAIR
-	armor = list(melee = 25, bullet = 20, laser = 15, energy = 15, bomb = 15, bio = 20, rad = 20, fire = 20, acid = 10)
+	armor = list(melee = 15, bullet = 15, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
 	cold_protection = CHEST|GROIN|LEGS|FEET|ARMS|HEAD
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HEAD
 	can_adjust = 0

--- a/code/modules/fallout/obj/clothing/under/pants.dm
+++ b/code/modules/fallout/obj/clothing/under/pants.dm
@@ -38,7 +38,7 @@
 	item_color = "madmax"
 	flags = THICKMATERIAL
 	body_parts_covered = LEGS
-	armor = list(melee = 30, bullet = 30, laser = 30, energy = 30, bomb = 30, bio = 30, rad = 30, fire = 30, acid = 30)
+	armor = list(melee = 25, bullet = 20, laser = 15, energy = 10, bomb = 10, bio = 30, rad = 30, fire = 30, acid = 30)
 
 /obj/item/clothing/under/pants/f13/johnclothes
 	name = "bedraggled ranger wear"

--- a/code/modules/fallout/projectiles/ammunition/energy.dm
+++ b/code/modules/fallout/projectiles/ammunition/energy.dm
@@ -12,18 +12,18 @@
 /obj/item/ammo_casing/energy/f13plasma/turbo
 	projectile_type = /obj/item/projectile/beam/plasma/turbo
 	delay = 5
-	e_cost = 75
+	e_cost = 50 //75 is far too punishing on the plasma caster, it reduces it to literally like 7 shots.
 
 /obj/item/ammo_casing/energy/f13plasma/tri
 	delay = 0
 	pellets = 3
 	variance = 25
-	e_cost = 35
+	e_cost = 85 //this does not apply per pellet for some reason, an increased cost should mean that you cant just fire it 60 times per magazine. It's a really fucking lethal weapon without being spammable too.
 	randomspread = 0
 
 /obj/item/ammo_casing/energy/laser/rcw
 	delay = 1
-	e_cost = 10
+	e_cost = 35 //cost increased because its super spammable with only 10pts, literally like 30 clicks to empty magazine and like 90 projectiles total.
 	projectile_type = /obj/item/projectile/beam/laser/rcw
 	randomspread = 1
 	variance = 8
@@ -33,7 +33,7 @@
 
 /obj/item/ammo_casing/energy/laser/rifle
 	delay = 4
-	e_cost = 50
+	e_cost = 35 //energy weapons use less power than plasma weapons, reduction here to bring it in line with AER13.
 	randomspread = 1
 	variance = 4
 
@@ -45,7 +45,7 @@
 	delay = 0
 	pellets = 3
 	variance = 25
-	e_cost = 35
+	e_cost = 85 //same deal as multiplas above, doesnt apply per pellet so has been increased to prevent near infinite ammo/solo 2 deathclaws with 1 magazine.
 	randomspread = 0
 
 /obj/item/ammo_casing/energy/laser/laer

--- a/code/modules/fallout/projectiles/ammunition/energy.dm
+++ b/code/modules/fallout/projectiles/ammunition/energy.dm
@@ -12,7 +12,7 @@
 /obj/item/ammo_casing/energy/f13plasma/turbo
 	projectile_type = /obj/item/projectile/beam/plasma/turbo
 	delay = 5
-	e_cost = 50 //75 is far too punishing on the plasma caster, it reduces it to literally like 7 shots.
+	e_cost = 50 //75 is far too punishing on the plasma caster, it reduces it to literally like 9 shots.
 
 /obj/item/ammo_casing/energy/f13plasma/tri
 	delay = 0

--- a/code/modules/fallout/projectiles/guns/energy.dm
+++ b/code/modules/fallout/projectiles/guns/energy.dm
@@ -35,9 +35,9 @@
 	weapon_weight = WEAPON_MEDIUM
 	w_class = WEIGHT_CLASS_BULKY
 	fire_sound = 'sound/f13weapons/plasmarifle.ogg'
-	burst_size = 2
+	burst_size = 1
 	shaded_charge = 1
-	fire_delay = 3
+	fire_delay = 2 //burst size decreased and fire delay increased slightly, should even out. the idea is basically just to make firefightsd more controllable, right now plasma/laser weapons and burst weapons in general are a pain in the ass because you end up missing half your burst rather than being able to predict per shot.
 
 /obj/item/weapon/gun/energy/plasma/glock
 	name ="glock 86"
@@ -85,9 +85,9 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/f13plasma/turbo)
 	weapon_weight = WEAPON_HEAVY
 	w_class = WEIGHT_CLASS_HUGE
-	fire_delay = 0
+	fire_delay = 1
 	w_class = 4
-	burst_size = 3
+	burst_size = 1 // fire delay increasd slightly and burst size decreased to 1, this weapon is basically just a harder hitting plasma rifle but comes with the downside of requiring you to use it with both hands, this means it is next to impossible to use flexibly in order to quickly reload from a belt short of some serious TG keybind memorisation and practice.
 
 ///////LASERS//////
 
@@ -99,7 +99,7 @@
 	desc = "Rapid capacitor weapon."
 	origin_tech = "combat=6;magnets=6"
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/rcw)
-	burst_size = 5 //Fuck yeah
+	burst_size = 5 //leaving this as a burst fire weapon since its meant to be a spammable weapon previous note here read: (Fuck yeah.)
 	w_class = 3
 	weapon_weight = WEAPON_MEDIUM
 	w_class = WEIGHT_CLASS_BULKY
@@ -126,7 +126,7 @@
 	desc = "A prototype laser rifle, meant to fire much faster and longer without overheating"
 	origin_tech = "combat=3;magnets=2"
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/rifle)
-	burst_size = 5
+	burst_size = 1 // to make the energy weapons more responsive.
 	w_class = 3
 	weapon_weight = WEAPON_MEDIUM
 	w_class = WEIGHT_CLASS_BULKY
@@ -137,7 +137,7 @@
 	icon_state = "laser-rifle13"
 	item_state = "laser-rifle13"
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/rifle/aer13)
-	burst_size = 5
+	burst_size = 1 // to make the energy weapons more responsive.
 
 /obj/item/weapon/gun/energy/laser/rifle/tri
 	name ="tribeam laser rifle"
@@ -151,12 +151,12 @@
 
 /obj/item/weapon/gun/energy/laser/laer
 	name = "LAER"
-	desc = "The Laser Assisted Electric Rifle is a prototype weapon developed at the Big Mountain Research Facility."
+	desc = "The Laser Assisted Electric Rifle is a prototype weapon developed at the Big Mountain Research Facility." // if you figure out how to make power armor vulnerable to electricity while further boosting durability, pulse weapons/electricity is the hardcounter to power armor.
 	icon = 'icons/fallout/objects/guns/energy.dmi'
 	icon_state = "laer"
 	item_state = "laer"
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/laer)
-	burst_size = 2
+	burst_size = 1 // to make the energy weapons more responsive.
 	w_class = 3
 	weapon_weight = WEAPON_MEDIUM
 	w_class = WEIGHT_CLASS_BULKY


### PR DESCRIPTION
to put a brief summary:

power armour stat lines organized according to tier, no longer is t-45 flat out better than APA mk1 and t-51.

ncr/legion armors adjusted slightly along with other armors to put them further away from power armour in terms of protection, combat armor given a slight boost at tier 2 and a slight nerf at tier 1, tier 1 is on par with power armour (t45) but lacks compared to later and tier 2 is more on par with stuff like t-51 / t-60 power armor.

some adjustments to clothing so that i cant immediately spawn with roundstart duster that gives me 50 bullet, melee and laser protection. also brought some more in line because a leather duster should not be providing more protection than ranger gear.

veteran ranger armor hasnt been adjusted as it is between combat armor mk1 and mk2 in terms of protection, ranger patrol armor has been brought down across board same as most armors to create disparity between ncr gear, old world combat armor and power armor.

NCR power armor has received a significant boost at a cost of more weight and speed, the idea here is less to be realistic and more to balance it - i played the majority of my ss13 on TGstation, so a lot of the balancing here is done from a gameplay point of view.

the changes made to the NCR salvaged power armor mean it now functions as a slow, tanky suit of armor ideal for fighting the legion or raiders, with high resistance to bullets and melee, but weak to explosives and energy weapons. it really is a suit of armour that the NCR has deployed solely as a linebreaker or shieldwall that other troopers can hide behind and with which the wearer can probably plug a gap in a line against half a dozen legionnaires even if they rush him in melee.

weapon adjustments made too, mostly to energy weapons - they now fire semi auto rather than burst because of the ammo waste, seriously. using burst on a plasma or laser gun wastes so much ammo its not even funny, should make the weapons more reliable now. also tweaked multiplas so it isnt the most OP thing in the game anymore, was draining far too little energy. did the same with the laser RCW but less so, weapon can still fire a lot just not 50 times as it could before.

some minor changes too, power armour now has correct flags for acid/fire protection, before it could still transfer since the acid/fire would get onto the armor and then transfer to components which were not flagged to be protected. also fixed temperature protection by giving power armour the firesuit stats.

(non-atmos, should protect against temps up to 800c, so can still kill someone in PA with fire but not with just a small campfire)

feel free to have a look through each and make decisions on case by case basis, can either discuss here or on discord: Pandemonium#1778

