### PR TITLE
general changes part 4(5?)

### DIFF
--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -185,8 +185,6 @@
 				return
 		if(!M.buckled)
 			return
-		var/matrix/m180 = matrix(M.transform)
-		animate(M, transform = m180, time = 3)
 		M.pixel_y = M.get_standard_pixel_y_offset(-32)
 		M.adjustBruteLoss(20)
 		src.visible_message(text("<span class='danger'>[M] falls free of the [src]!</span>"))

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -86,10 +86,6 @@
 			L.adjustBruteLoss(30)
 			L.setDir(2)
 			buckle_mob(L, force=1)
-			var/matrix/m180 = matrix(L.transform)
-			m180.Turn(180)
-			animate(L, transform = m180, time = 3)
-			L.pixel_y = L.get_standard_pixel_y_offset(180)
 	else if (has_buckled_mobs())
 		for(var/mob/living/L in buckled_mobs)
 			user_unbuckle_mob(L, user)
@@ -128,10 +124,6 @@
 				return
 		if(!M.buckled)
 			return
-		var/matrix/m180 = matrix(M.transform)
-		m180.Turn(180)
-		animate(M, transform = m180, time = 3)
-		M.pixel_y = M.get_standard_pixel_y_offset(180)
 		M.adjustBruteLoss(30)
 		src.visible_message(text("<span class='danger'>[M] falls free of the [src]!</span>"))
 		unbuckle_mob(M,force=1)
@@ -154,10 +146,10 @@
 	desc = "A cross fashioned from an old telephone pole and some rope."
 	density = 1
 	anchored = 1
-	buckle_lying = 0
 	can_buckle = 1
-	bound_height = 64
-	
+	obj_integrity = 250
+	max_integrity = 250
+
 /obj/structure/kitchenspike/cross/user_unbuckle_mob(mob/living/buckled_mob, mob/living/carbon/human/user)
 	if(buckled_mob)
 		var/mob/living/M = buckled_mob
@@ -178,15 +170,18 @@
 			"<span class='warning'>[M.name] struggles to break free from the [src]!</span>",\
 			"<span class='notice'>You struggle to break free from the [src], exacerbating your wounds! (Stay still for two minutes.)</span>",\
 			"<span class='italics'>You hear a dry sticky noise..</span>")
-			M.adjustBruteLoss(20)
+			M.adjustBruteLoss(45)
 			if(!do_after(M, 1200, target = src))
 				if(M && M.buckled)
 					to_chat(M, "<span class='warning'>You fail to free yourself!</span>")
 				return
 		if(!M.buckled)
 			return
-		M.pixel_y = M.get_standard_pixel_y_offset(-32)
-		M.adjustBruteLoss(20)
+		var/matrix/minvert = matrix(M.transform)
+		minvert.Turn(1)
+		animate(M, transform = minvert)
+		M.pixel_y = M.get_standard_pixel_y_offset(35)
+		M.adjustBruteLoss(45)
 		src.visible_message(text("<span class='danger'>[M] falls free of the [src]!</span>"))
 		unbuckle_mob(M,force=1)
 		M.emote("scream")

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -156,9 +156,8 @@
 	anchored = 1
 	buckle_lying = 0
 	can_buckle = 1
-	bound_height = 180
-	bound_width´= 1
-
+	bound_height = 64
+	
 /obj/structure/kitchenspike/cross/user_unbuckle_mob(mob/living/buckled_mob, mob/living/carbon/human/user)
 	if(buckled_mob)
 		var/mob/living/M = buckled_mob
@@ -188,7 +187,7 @@
 			return
 		var/matrix/m180 = matrix(M.transform)
 		animate(M, transform = m180, time = 3)
-		M.pixel_y = M.get_standard_pixel_y_offset(32)
+		M.pixel_y = M.get_standard_pixel_y_offset(-32)
 		M.adjustBruteLoss(20)
 		src.visible_message(text("<span class='danger'>[M] falls free of the [src]!</span>"))
 		unbuckle_mob(M,force=1)

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -156,7 +156,8 @@
 	anchored = 1
 	buckle_lying = 0
 	can_buckle = 1
-	bound_height = 64
+	bound_height = 180
+	bound_width´= 1
 
 /obj/structure/kitchenspike/cross/user_unbuckle_mob(mob/living/buckled_mob, mob/living/carbon/human/user)
 	if(buckled_mob)

--- a/code/modules/fallout/misc/jobs/job/brotherhood.dm
+++ b/code/modules/fallout/misc/jobs/job/brotherhood.dm
@@ -4,13 +4,13 @@
 	title = "Elder"
 	desc = "A mentor, the source of wisdom.<br>You are the one who shall fulfill destiny."
 	flag = ELDER
-	department_head = list("Brotherhood of Steel command HQ")
+	department_head = list("Brotherhood of Steel High Command")
 	department_flag = ENGSEC
 	faction = "bs"
 	status = "elder"
 	total_positions = 1
 	spawn_positions = 1
-	supervisors = "the Brotherhood of Steel command HQ"
+	supervisors = "the Brotherhood of Steel High Command"
 	selection_color = "#ec9d9d"
 	minimal_player_age = 7
 	whitelist_on = 0

--- a/code/modules/fallout/misc/jobs/job/enclave.dm
+++ b/code/modules/fallout/misc/jobs/job/enclave.dm
@@ -22,6 +22,7 @@
 	/obj/item/clothing/head/helmet/power_armor/shocktrooper,
 	/obj/item/weapon/gun/energy/plasma,
 	/obj/item/weapon/lighter/engraved
+	/obj/item/weapon/cqc_manual
 	)
 
 	denied_items = list(
@@ -91,6 +92,7 @@
 	/obj/item/clothing/head/helmet/power_armor/superadvanced,
 	/obj/item/weapon/gun/energy/plasma,
 	/obj/item/weapon/lighter/engraved
+	/obj/item/weapon/cqc_manual
 	)
 
 	denied_items = list(

--- a/code/modules/fallout/misc/jobs/job/enclave.dm
+++ b/code/modules/fallout/misc/jobs/job/enclave.dm
@@ -61,7 +61,7 @@
 	/obj/item/weapon/reknife = 1,
 	/obj/item/clothing/glasses/sunglassespaop = 1,
 	/obj/item/clothing/ears/earmuffs = 1,
-	/obj/item/weapon/implant/cqc = 1)
+	/obj/item/weapon/implanter/cqc = 1)
 	id = /obj/item/weapon/card/id/enclave
 
 //Enclave Lieutenant
@@ -131,7 +131,7 @@
 	/obj/item/weapon/reknife = 1,
 	/obj/item/clothing/glasses/sunglassespaop = 1,
 	/obj/item/clothing/ears/earmuffs = 1,
-	/obj/item/weapon/implant/cqc = 1)
+	/obj/item/weapon/implanter/cqc = 1)
 	id = /obj/item/weapon/card/id/enclave
 
 //Enclave Private

--- a/code/modules/fallout/misc/jobs/job/enclave.dm
+++ b/code/modules/fallout/misc/jobs/job/enclave.dm
@@ -4,13 +4,13 @@
 	title = "Colonel"
 	desc = "An actual American patriot.<br>You live by the principle that the Main Goal is more important than the means of achieving it."
 	flag = COLONEL
-	department_head = list("Enclave command HQ")
+	department_head = list("Enclave Central Command")
 	department_flag = MEDSCI
 	faction = "enclave"
 	status = "colonel"
 	total_positions = 1
 	spawn_positions = 1
-	supervisors = "the Enclave command HQ"
+	supervisors = "the Enclave Central Command"
 	selection_color = "#ec9d9d"
 	minimal_player_age = 7
 	whitelist_on = 0
@@ -54,7 +54,7 @@
 	shoes = /obj/item/clothing/shoes/f13/military
 	suit = /obj/item/clothing/suit/f13/autumn
 	belt = /obj/item/weapon/storage/belt/military/army
-	weapon = /obj/item/weapon/gun/energy/plasma/pistol
+	weapon = null
 	belt_contents = list(
 	/obj/item/weapon/reagent_containers/hypospray/combat = 1,
 	/obj/item/device/radio = 1,
@@ -124,7 +124,7 @@
 	suit = null
 	head = /obj/item/clothing/head/soft/f13/enclave
 	belt = /obj/item/weapon/storage/belt/military/army
-	weapon = /obj/item/weapon/gun/energy/plasma/pistol
+	weapon = null
 	belt_contents = list(
 	/obj/item/weapon/reagent_containers/hypospray/combat = 1,
 	/obj/item/device/radio = 1,

--- a/code/modules/fallout/misc/jobs/job/enclave.dm
+++ b/code/modules/fallout/misc/jobs/job/enclave.dm
@@ -57,11 +57,11 @@
 	weapon = null
 	belt_contents = list(
 	/obj/item/weapon/reagent_containers/hypospray/combat = 1,
+	/obj/item/weapon/implanter/cqc = 1,
 	/obj/item/device/radio = 1,
 	/obj/item/weapon/reknife = 1,
 	/obj/item/clothing/glasses/sunglassespaop = 1,
-	/obj/item/clothing/ears/earmuffs = 1,
-	/obj/item/weapon/implanter/cqc = 1)
+	/obj/item/clothing/ears/earmuffs = 1)
 	id = /obj/item/weapon/card/id/enclave
 
 //Enclave Lieutenant
@@ -127,11 +127,11 @@
 	weapon = null
 	belt_contents = list(
 	/obj/item/weapon/reagent_containers/hypospray/combat = 1,
+	/obj/item/weapon/implanter/cqc = 1,
 	/obj/item/device/radio = 1,
 	/obj/item/weapon/reknife = 1,
 	/obj/item/clothing/glasses/sunglassespaop = 1,
-	/obj/item/clothing/ears/earmuffs = 1,
-	/obj/item/weapon/implanter/cqc = 1)
+	/obj/item/clothing/ears/earmuffs = 1)
 	id = /obj/item/weapon/card/id/enclave
 
 //Enclave Private

--- a/code/modules/fallout/misc/jobs/job/enclave.dm
+++ b/code/modules/fallout/misc/jobs/job/enclave.dm
@@ -60,7 +60,8 @@
 	/obj/item/device/radio = 1,
 	/obj/item/weapon/reknife = 1,
 	/obj/item/clothing/glasses/sunglassespaop = 1,
-	/obj/item/clothing/ears/earmuffs = 1)
+	/obj/item/clothing/ears/earmuffs = 1,
+	/obj/item/weapon/implant/cqc = 1)
 	id = /obj/item/weapon/card/id/enclave
 
 //Enclave Lieutenant
@@ -129,7 +130,8 @@
 	/obj/item/device/radio = 1,
 	/obj/item/weapon/reknife = 1,
 	/obj/item/clothing/glasses/sunglassespaop = 1,
-	/obj/item/clothing/ears/earmuffs = 1)
+	/obj/item/clothing/ears/earmuffs = 1,
+	/obj/item/weapon/implant/cqc = 1)
 	id = /obj/item/weapon/card/id/enclave
 
 //Enclave Private

--- a/code/modules/fallout/misc/jobs/job/enclave.dm
+++ b/code/modules/fallout/misc/jobs/job/enclave.dm
@@ -23,7 +23,7 @@
 	/obj/item/weapon/gun/energy/plasma,
 	/obj/item/weapon/lighter/engraved,
 	/obj/item/weapon/cqc_manual
-	
+
 	)
 
 	denied_items = list(
@@ -59,7 +59,6 @@
 	weapon = null
 	belt_contents = list(
 	/obj/item/weapon/reagent_containers/hypospray/combat = 1,
-	/obj/item/weapon/cqc_manual = 1,
 	/obj/item/device/radio = 1,
 	/obj/item/weapon/reknife = 1,
 	/obj/item/clothing/glasses/sunglassespaop = 1,
@@ -130,7 +129,6 @@
 	weapon = null
 	belt_contents = list(
 	/obj/item/weapon/reagent_containers/hypospray/combat = 1,
-	/obj/item/weapon/cqc_manual = 1,
 	/obj/item/device/radio = 1,
 	/obj/item/weapon/reknife = 1,
 	/obj/item/clothing/glasses/sunglassespaop = 1,

--- a/code/modules/fallout/misc/jobs/job/enclave.dm
+++ b/code/modules/fallout/misc/jobs/job/enclave.dm
@@ -21,8 +21,9 @@
 	/obj/item/clothing/suit/armor/f13/power_armor/shocktrooper,
 	/obj/item/clothing/head/helmet/power_armor/shocktrooper,
 	/obj/item/weapon/gun/energy/plasma,
-	/obj/item/weapon/lighter/engraved
+	/obj/item/weapon/lighter/engraved,
 	/obj/item/weapon/cqc_manual
+	
 	)
 
 	denied_items = list(
@@ -91,7 +92,7 @@
 	/obj/item/clothing/suit/armor/f13/power_armor/superadvanced,
 	/obj/item/clothing/head/helmet/power_armor/superadvanced,
 	/obj/item/weapon/gun/energy/plasma,
-	/obj/item/weapon/lighter/engraved
+	/obj/item/weapon/lighter/engraved,
 	/obj/item/weapon/cqc_manual
 	)
 
@@ -162,6 +163,7 @@
 	/obj/item/clothing/ears/earmuffs,
 	/obj/item/clothing/glasses/sunglassespaop,
 	/obj/item/weapon/gun/energy/plasma/pistol
+	/obj/item/weapon/cqc_manual
 	)
 
 	denied_items = list(

--- a/code/modules/fallout/misc/jobs/job/enclave.dm
+++ b/code/modules/fallout/misc/jobs/job/enclave.dm
@@ -162,9 +162,7 @@
 	/obj/item/clothing/head/soft/f13/utility/olive,
 	/obj/item/clothing/ears/earmuffs,
 	/obj/item/clothing/glasses/sunglassespaop,
-	/obj/item/weapon/gun/energy/plasma/pistol
-	/obj/item/weapon/cqc_manual
-	)
+	/obj/item/weapon/gun/energy/plasma/pistol)
 
 	denied_items = list(
 	/obj/item/clothing/shoes/f13/rag,

--- a/code/modules/fallout/misc/jobs/job/enclave.dm
+++ b/code/modules/fallout/misc/jobs/job/enclave.dm
@@ -57,7 +57,7 @@
 	weapon = null
 	belt_contents = list(
 	/obj/item/weapon/reagent_containers/hypospray/combat = 1,
-	/obj/item/weapon/implanter/cqc = 1,
+	/obj/item/weapon/cqc_manual = 1,
 	/obj/item/device/radio = 1,
 	/obj/item/weapon/reknife = 1,
 	/obj/item/clothing/glasses/sunglassespaop = 1,
@@ -127,7 +127,7 @@
 	weapon = null
 	belt_contents = list(
 	/obj/item/weapon/reagent_containers/hypospray/combat = 1,
-	/obj/item/weapon/implanter/cqc = 1,
+	/obj/item/weapon/cqc_manual = 1,
 	/obj/item/device/radio = 1,
 	/obj/item/weapon/reknife = 1,
 	/obj/item/clothing/glasses/sunglassespaop = 1,

--- a/code/modules/fallout/misc/weight.dm
+++ b/code/modules/fallout/misc/weight.dm
@@ -12,15 +12,15 @@
 			if(0)
 				self_weight = 0
 			if(1)
-				self_weight = 3.500
+				self_weight = 0.500
 			if(2)
-				self_weight = 9.500
+				self_weight = 3.500
 			if(3)
-				self_weight = 18.000
+				self_weight = 6.000
 			if(4)
-				self_weight = 22.000
+				self_weight = 8.000
 			if(5)
-				self_weight = 26.000
+				self_weight = 20.000
 			if(6)
 				self_weight = 30.000
 	if(istype(loc, /atom/movable))

--- a/code/modules/fallout/misc/weight.dm
+++ b/code/modules/fallout/misc/weight.dm
@@ -12,15 +12,15 @@
 			if(0)
 				self_weight = 0
 			if(1)
-				self_weight = 0.500
+				self_weight = 3.500
 			if(2)
-				self_weight = 1.500
+				self_weight = 9.500
 			if(3)
-				self_weight = 3.000
-			if(4)
-				self_weight = 12.000
-			if(5)
 				self_weight = 18.000
+			if(4)
+				self_weight = 22.000
+			if(5)
+				self_weight = 26.000
 			if(6)
 				self_weight = 30.000
 	if(istype(loc, /atom/movable))

--- a/code/modules/fallout/misc/weight.dm
+++ b/code/modules/fallout/misc/weight.dm
@@ -18,11 +18,11 @@
 			if(3)
 				self_weight = 3.000
 			if(4)
-				self_weight = 8.000
+				self_weight = 12.000
 			if(5)
-				self_weight = 14.000
+				self_weight = 18.000
 			if(6)
-				self_weight = 25.000
+				self_weight = 30.000
 	if(istype(loc, /atom/movable))
 		var/atom/movable/L = loc
 		L.update_weight(self_weight)

--- a/code/modules/fallout/obj/chems.dm
+++ b/code/modules/fallout/obj/chems.dm
@@ -3,38 +3,38 @@
 /obj/item/weapon/reagent_containers/pill/patch/healingpowder
 	name = "healing powder"
 	desc = "A foul-smelling primitive healing medicine.<br>It is widespread in the wasteland due to easy production - all kinds of Wastelanders from Settlers to Mercenaries use it to heal minor injuries.<br>Soldiers of the Legion use healing powder as their primary source of medicine and healing, since the Legion bans the use of other chems, such as stimpaks."
-	list_reagents = list("omnizine" = 20, "salglu_solution" = 10)
+	list_reagents = list("omnizine" = 15, "salglu_solution" = 10) // slight reduction in omnizine content as it metabolizes very slowly, 15u can last like 10 minutes.
 	icon = 'icons/fallout/objects/medicine/chemical.dmi'
 	icon_state = "heal_powder"
 	item_state = "bandaid"
-	self_weight = 0.05
+	self_weight = 0.01
 
 /obj/item/weapon/reagent_containers/pill/patch/stimpak
 	name = "stimpak"
 	desc = "A stimpak, or stimulation delivery package, is a type of hand-held medication used for healing the body. This item consists of a syringe for containing and delivering the medication and a gauge for measuring the status of the stimpak's contents. When the medicine is injected, it provides immediate healing of the body's minor wounds."
-	list_reagents = list("styptic_powder" = 20, "silver_sulfadiazine" = 20, "oxandrolone" = 5, "morphine" = 5)
+	list_reagents = list("styptic_powder" = 20, "silver_sulfadiazine" = 20, "oxandrolone" = 5, "stimulants" = 5)
 	icon = 'icons/fallout/objects/medicine/syringe.dmi'
 	icon_state = "stim_15"
 	item_state = "syringe_15"
-	self_weight = 0.1
+	self_weight = 0.01
 
 /obj/item/weapon/reagent_containers/pill/patch/supstimpak
 	name = "super stimpak"
-	desc = "The super version of the Stimpak has an additional vial containing more powerful drugs than the basic model, as well as a leather belt to strap the needle to the injured limb."
-	list_reagents = list("styptic_powder" = 40, "silver_sulfadiazine" = 40, "oxandrolone" = 10, "morphine" = 10, "salglu_solution" = 20)
+	desc = "The super version of the Stimpak has an additional vial containing more powerful drugs than the basic model, as well as a leather belt to strap the needle to the injured limb." // removed morphine from both this and regular stimpacks, they are purely for healing wounds - painkilling is done by med-x.
+	list_reagents = list("styptic_powder" = 50, "silver_sulfadiazine" = 50, "oxandrolone" = 15, "stimulants" = 15, "salglu_solution" = 45)
 	icon = 'icons/fallout/objects/medicine/syringe.dmi'
 	icon_state = "superstim_15"
 	item_state = "syringe_15"
-	self_weight = 0.1
+	self_weight = 0.01
 
 /obj/item/weapon/reagent_containers/pill/patch/medx
 	name = "med-x"
 	desc = "Med-X is a potent opiate analgesic that binds to opioid receptors in the brain and central nervous system, reducing the perception of pain as well as the emotional response to pain.<br>Essentially, it is a painkiller delivered via hypodermic needle."
-	list_reagents = list("methamphetamine" = 9, "krokodil" = 9, "styptic_powder" = 10, "silver_sulfadiazine" = 10)
+	list_reagents = list("methamphetamine" = 5, "morphine" = 15) // this thing having meth is ok, krokodil not so much. it's basically fallout's version of morphine, not adrenaline.
 	icon = 'icons/fallout/objects/medicine/syringe.dmi'
 	icon_state = "medx_15"
 	item_state = "syringe_15"
-	self_weight = 0.1
+	self_weight = 0.01
 
 /obj/item/weapon/reagent_containers/pill/patch/radaway
 	name = "radaway"
@@ -43,25 +43,25 @@
 	icon = 'icons/fallout/objects/medicine/bloodpack.dmi'
 	icon_state = "radaway"
 	item_state = "syringe_15"
-	self_weight = 0.1
+	self_weight = 0.01
 
 /obj/item/weapon/reagent_containers/pill/patch/jet
 	name = "jet"
 	desc = "Jet is a highly addictive drug first synthesized by Myron. It is extracted from the fumes of brahmin feces and administered via an inhaler."
-	list_reagents = list("stimulants" = 20, "crank" = 10)
+	list_reagents = list("stimulants" = 10, "crank" = 6, "krokodil" = 4) // reduced crank component as 10u caused instant addiction, meaning one hit was a guaranteed hook.
 	icon = 'icons/fallout/objects/medicine/chemical.dmi'
 	icon_state = "jet"
 	item_state = "bandaid"
-	self_weight = 0.1
+	self_weight = 0.01
 
 /obj/item/weapon/reagent_containers/pill/patch/psycho
 	name = "psycho"
 	desc = "Psycho will increase damage resistance, allowing subjects to survive hits more easily."
-	list_reagents = list("epinephrine" = 20, "inacusiate" = 5, "oculine" = 5)
+	list_reagents = list("epinephrine" = 30, "inacusiate" = 10, "oculine" = 10) //increasing this just slightly to make psycho more worth using.
 	icon = 'icons/fallout/objects/medicine/syringe.dmi'
 	icon_state = "psycho"
 	item_state = "syringe_15"
-	self_weight = 0.1
+	self_weight = 0.01
 
 /obj/item/weapon/reagent_containers/pill/patch/radx
 	name = "rad-x"
@@ -70,13 +70,13 @@
 	icon = 'icons/fallout/objects/medicine/chemical.dmi'
 	icon_state = "radx"
 	item_state = "bandaid"
-	self_weight = 0.1
+	self_weight = 0.01
 
 /obj/item/weapon/reagent_containers/pill/patch/turbo
 	name = "turbo"
 	desc = "Turbo appears to be an inhaler of Jet hastily duct-taped to an aerosol can of HairStylez-brand hair spray. Turbo causes brief slowdown of the user's surroundings (time goes at about 35% of its original speed), including everything from enemy movements to projectile speeds (the user's own projectile speed included) to the duration of the drug itself. However, the user does not experience the slowdown - their own movement speed and fire rate will remain the same."
-	list_reagents = list("stimulants" = 10, "methamphetamine" = 9)
+	list_reagents = list("stimulants" = 3, "methamphetamine" = 3, "crank" = 3) // stims & meth filter out slowly due to server tickrate, this much should last for roughly 4 minutes.
 	icon = 'icons/fallout/objects/medicine/chemical.dmi'
 	icon_state = "turbo"
 	item_state = "turbo"
-	self_weight = 0.1
+	self_weight = 0.01

--- a/code/modules/fallout/obj/clothing/suits/armor.dm
+++ b/code/modules/fallout/obj/clothing/suits/armor.dm
@@ -324,7 +324,7 @@
 	put_on_delay = 40
 	strip_delay = 40
 	resistance_flags = FIRE_PROOF
-	self_weight = 7
+	self_weight = 4
 
 /obj/item/clothing/suit/armor/f13/ncr/salvaged
 	name = "NCR salvaged power armor"
@@ -337,7 +337,7 @@
 	flags_inv = HIDEJUMPSUIT
 	put_on_delay = 150
 	strip_delay = 150
-	self_weight = 30
+	self_weight = 60
 	slowdown = 2
 	armor = list(melee = 90, bullet = 90, laser = 35, energy = 35, bomb = 5, bio = 100, rad = 100, fire = 100, acid = 100) //These changes aren't necessarily realistic as no servomotors = less effective at disappating oncoming force but should serve to give NCR heavy troopers an actual role in combat. Should be far better suited towards a defensive playstyle against ballistic weapons.
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
@@ -348,7 +348,7 @@
 	icon_state = "sierra"
 	item_state = "sierra"
 	armor = list(melee = 85, bullet = 85, laser = 55, energy = 55, bomb = 45, bio = 100, rad = 100, fire = 100, acid = 100)
-	self_weight = 18 //weight adjusted and general behaviour put more in line with regular power armour since sierra power armour is meant to have its servomotors still installed and used by captains that have been trained to use power armour
+	self_weight = 26 //weight adjusted and general behaviour put more in line with regular power armour since sierra power armour is meant to have its servomotors still installed and used by captains that have been trained to use power armour
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	
 // ncr armor end
@@ -410,7 +410,7 @@
 	icon_state = "t45dpowerarmor"
 	item_state = "t45dpowerarmor"
 	armor = list(melee = 85, bullet = 85, laser = 45, energy = 45, bomb = 55, bio =100, rad = 100, fire = 100, acid = 100)
-	self_weight = 18
+	self_weight = 26
 
 /obj/item/clothing/suit/armor/f13/power_armor/t51b
 	name = "T-51b power armor"
@@ -418,7 +418,7 @@
 	icon_state = "t51bpowerarmor"
 	item_state = "t51bpowerarmor"
 	armor = list(melee = 85, bullet = 90, laser = 50, energy = 50, bomb = 55, bio = 100, rad = 100, fire = 100, acid = 100)
-	self_weight = 18
+	self_weight = 28
 
 /obj/item/clothing/suit/armor/f13/power_armor/t60
 	name = "T-60 power armor"
@@ -426,7 +426,7 @@
 	icon_state = "t60powerarmor"
 	item_state = "t60powerarmor"
 	armor = list(melee = 85, bullet = 95, laser = 55, energy = 55, bomb = 45, bio = 100, rad = 100, fire = 100, acid = 100)
-	self_weight = 18
+	self_weight = 30
 
 // enclave armors
 
@@ -436,7 +436,7 @@
 	icon_state = "advanced"
 	item_state = "advanced"
 	armor = list(melee = 95, bullet = 95, laser = 70, energy = 70, bomb = 55, bio = 100, rad = 100, fire = 100, acid = 100)
-	self_weight = 18
+	self_weight = 26
 
 /obj/item/clothing/suit/armor/f13/power_armor/superadvanced
 	name = "advanced power armor Mk. II 'Bugman'"
@@ -444,7 +444,7 @@
 	icon_state = "advanced"
 	item_state = "advanced"
 	armor = list(melee = 98, bullet = 98, laser = 80, energy = 80, bomb = 55, bio = 100, rad = 100, fire = 100, acid = 100)
-	self_weight = 12
+	self_weight = 22
 
 /obj/item/clothing/suit/armor/f13/power_armor/shocktrooper
 	name = "advanced power armor Mk. III 'Black Devil'" //for the sake of lore consistency, taking both bethesda and black isle/interplays versions and just saying the one in fo3 is the mark 3, with mark 2 being last of the first apa iterations. also fixed the name because hellfire is the one from broken steel, this one is the black devil/standard apa from fo3. Nicknames have also been added to the armors.
@@ -452,7 +452,7 @@
 	icon_state = "shocktrooper" //probably need a new sprite of this to fit with the higher detail style of the new APA
 	item_state = "shocktrooper" //probably need a new sprite of this to fit with the higher detail style of the new APA
 	armor = list(melee = 105, bullet = 105, laser = 85, energy = 85, bomb = 60, bio = 100, rad = 100, fire = 100, acid = 100)
-	self_weight = 15
+	self_weight = 24
 
 /obj/item/clothing/suit/armor/f13/power_armor/tesla
 	name = "advanced tesla power armor Mk. I 'Glow Worm'"
@@ -460,7 +460,7 @@
 	icon_state = "tesla" //placeholder will use tesla sprite for now, needs a tesla version of the new APA though.
 	item_state = "tesla" //placeholder will use tesla sprite for now, needs a tesla version of the new APA though.
 	armor = list(melee = 65, bullet = 65, laser = 98, energy = 98, bomb = 55, bio = 100, rad = 100, fire = 100, acid = 100)
-	self_weight = 15
+	self_weight = 26
 
 /obj/item/clothing/suit/armor/f13/power_armor/badmin
 	name = "advanced power armor Mk. IV 'Hellfire'"
@@ -468,7 +468,7 @@
 	icon_state = "PLACEHOLDERFORHELLFIRESPRITE!!!" //replacing with error for now since its unsuable anyway, would love a hellfire sprite...
 	item_state = "PLACEHOLDERFORHELLFIRESPRITE!!!" //replacing with error for now since its unsuable anyway, would love a hellfire sprite...
 	armor = list(melee = 105, bullet = 105, laser = 200, energy = 200, bomb = 75, bio = 100, rad = 100, fire = 100, acid = 100) //Burn baby, burn!
-	self_weight = 18
+	self_weight = 26
 
 //Knights of the Apocalypse
 

--- a/code/modules/fallout/obj/flora/farming.dm
+++ b/code/modules/fallout/obj/flora/farming.dm
@@ -8,9 +8,9 @@
 	species = "broc"
 	plantname = "Broc Bush"
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/broc
-	lifespan = 25
-	endurance = 10
-	yield = 2
+	lifespan = 45
+	endurance = 60
+	yield = 4
 	growthstages = 3
 	production = 4
 	maturation = 4
@@ -30,9 +30,9 @@
 	species = "xander"
 	plantname = "Xander Root"
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/xander
-	lifespan = 25
-	endurance = 10
-	yield = 1
+	lifespan = 45
+	endurance = 60
+	yield = 4
 	growthstages = 3
 	production = 1
 	maturation = 1
@@ -50,8 +50,8 @@
 	species = "mutfruit"
 	plantname = "Mutfruit"
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/mutfruit
-	lifespan = 30
-	endurance = 20
+	lifespan = 45
+	endurance = 80
 	yield = 3
 	growthstages = 3
 	production = 5

--- a/code/modules/fallout/obj/spawners/lootdrops.dm
+++ b/code/modules/fallout/obj/spawners/lootdrops.dm
@@ -37,28 +37,21 @@
 	loot = list(
 	/obj/item/weapon/gun/ballistic/automatic/assault_rifle = 1,
 	/obj/item/weapon/gun/ballistic/shotgun/rifle = 1,
-	/obj/item/weapon/gun/ballistic/shotgun/rifle/scope = 1,
 	/obj/item/weapon/gun/ballistic/shotgun/trail = 1)
 
 /obj/effect/spawner/lootdrop/wrange_high
 	color = "#FFAAFA"
 	loot = list(
-	/obj/item/weapon/gun/energy/laser/rifle = 1,
+	/obj/item/weapon/gun/energy/laser/pistol = 1,
 	/obj/item/weapon/gun/energy/plasma/pistol = 1,
-	/obj/item/weapon/gun/energy/plasma/glock = 1,
-	/obj/item/weapon/gun/energy/plasma = 1,
 	/obj/item/weapon/gun/ballistic/automatic/smg10mm = 1,
-	/obj/item/weapon/gun/ballistic/automatic/rifle = 1)
+	/obj/item/weapon/gun/ballistic/automatic/assault_rifle = 1)
 
 /obj/effect/spawner/lootdrop/wrange_legend
 	color = "#FF0000"
 	loot = list(
-	/obj/item/weapon/gun/ballistic/automatic/bozar = 25,
 	/obj/item/weapon/gun/ballistic/revolver/magnum = 1,
-	/obj/item/weapon/gun/energy/laser/rifle/tri = 25,
-	/obj/item/weapon/gun/energy/plasma/turbo = 25,
-	/obj/item/weapon/gun/energy/laser/rifle/aer13 = 1,
-	/obj/item/weapon/gun/energy/plasma/tri = 25)
+	/obj/item/weapon/gun/energy/laser/rifle/aer13 = 1)
 
 /obj/effect/spawner/lootdrop/ammo
 	color = "#FF00FF"
@@ -210,8 +203,6 @@
 /obj/effect/spawner/lootdrop/clothing_legend
 	color = "#FF0000"
 	loot = list(
-	/obj/item/clothing/head/helmet/power_armor/t45d = 1,
 	/obj/item/clothing/head/helmet/power_armor/ncr = 1,
-	/obj/item/clothing/suit/armor/f13/power_armor/t45d = 1,
 	/obj/item/clothing/suit/armor/f13/ncr/salvaged = 1,
 	/obj/item/clothing/under/f13/recon = 1)

--- a/code/modules/mob/dead/observer/say.dm
+++ b/code/modules/mob/dead/observer/say.dm
@@ -18,5 +18,4 @@
 		else
 			speaker = V.source
 	var/link = FOLLOW_LINK(src, speaker)
-	to_chat(src, "[link] [message]")
-
+	src << "[link] [message]"

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -49,16 +49,15 @@
 	timeofdeath = world.time
 	tod = worldtime2text()
 	var/turf/T = get_turf(src)
-	if(mind && mind.name && mind.active && (T.z != ZLEVEL_CENTCOM))
+	if(mind && mind.name && mind.active && (!(T.flags)))
 		var/area/A = get_area(T)
-		var/rendered = "<span class='deadsay'><b>[mind.name]</b> has died at <b>[A.name]</b>.</span>"
+		var/rendered = "<span class='deadsay'><b>[mind.name]</b> has met their fate at <b>[A.name]</b>.</span>"
 		deadchat_broadcast(rendered, follow_target = src, message_type=DEADCHAT_DEATHRATTLE)
 	if(mind)
 		mind.store_memory("Time of death: [tod]", 0)
 	living_mob_list -= src
 	if(!gibbed)
 		dead_mob_list += src
-	to_chat(src, "Wait for respawn at look at this screen. OOC -> Respawn.")
 	paralysis = 0
 	stunned = 0
 	weakened = 0
@@ -73,6 +72,4 @@
 	update_canmove()
 	med_hud_set_health()
 	med_hud_set_status()
-	if(client)
-		client.screen += PoolOrNew(/obj/screen/fullscreen/death)
 	return TRUE

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -120,7 +120,7 @@
 		new_player_panel()
 
 	if(href_list["contribute"])
-		src << link("http://fallout13.ru/payment/index.php?ckey=[client.ckey]")
+		src << link("https://github.com/tichys/Fallout-13")
 
 	if(href_list["observe"])
 


### PR DESCRIPTION
re-enabled the ability to ghost out of bodies while alive or dead. couldnt figure out how to get observe to work, but does mean people can take a pause between lives and just watch the action for a bit which was the point of this.

fixed the cross' buckle location, now bodies/people should be placed upright correctly on the cross when buckled to it. also increased the damage taken when attempting to escape from a cross and failing.

increased plant endurance/yield for wasteland-native plants, both to encourage botany and because these wasteland plants should be very hardy, they thrive in an environment so hostile to most forms of natural life it's pretty absurd.

added cqc materials to enclave colonel/lieutenant to beef up their melee capabilities a bit.

reduced spawns/removed some items from spawnlists so you can't find a multiplas or a turbo plasma(caster) just lying around.

tweaked the weight brackets slightly so lighter armour/loadouts are less punished with heavier loadouts almost always falling into the slowest bracket of movement speed.