### PR TITLE
general changes part 5

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -75,14 +75,6 @@
 		foundrecord.fields["rank"] = assignment
 
 /datum/datacore/proc/get_manifest(monochrome, OOC)
-	var/list/heads = list()
-	var/list/sec = list()
-	var/list/eng = list()
-	var/list/med = list()
-	var/list/sci = list()
-	var/list/sup = list()
-	var/list/civ = list()
-	var/list/bot = list()
 	var/list/vault = list()
 	var/list/brotherhood = list()
 	var/list/enclave = list()
@@ -110,30 +102,6 @@
 		var/name = t.fields["name"]
 		var/rank = t.fields["rank"]
 		var/department = 0
-		if(rank in command_positions)
-			heads[name] = rank
-			department = 1
-		if(rank in security_positions)
-			sec[name] = rank
-			department = 1
-		if(rank in engineering_positions)
-			eng[name] = rank
-			department = 1
-		if(rank in medical_positions)
-			med[name] = rank
-			department = 1
-		if(rank in science_positions)
-			sci[name] = rank
-			department = 1
-		if(rank in supply_positions)
-			sup[name] = rank
-			department = 1
-		if(rank in civilian_positions)
-			civ[name] = rank
-			department = 1
-		if(rank in nonhuman_positions)
-			bot[name] = rank
-			department = 1
 		if(rank in vault_occupations)
 			vault[name] = rank
 			department = 1
@@ -160,16 +128,6 @@
 			department = 1
 		if(!department && !(name in heads))
 			misc[name] = rank
-	if(heads.len > 0)
-		dat += "<tr><th colspan=3>Heads</th></tr>"
-		for(var/name in heads)
-			dat += "<tr[even ? " class='alt'" : ""]><td>[name]</td><td>[heads[name]]</td></tr>"
-			even = !even
-	if(sec.len > 0)
-		dat += "<tr><th colspan=3>Security</th></tr>"
-		for(var/name in sec)
-			dat += "<tr[even ? " class='alt'" : ""]><td>[name]</td><td>[sec[name]]</td></tr>"
-			even = !even
 	if(vault.len > 0)
 		dat += "<tr><th colspan=3>Vault 113</th></tr>"
 		for(var/name in vault)
@@ -209,37 +167,6 @@
 		dat += "<tr><th colspan=3>105th Special Defense Battalion</th></tr>"
 		for(var/name in enclave)
 			dat += "<tr[even ? " class='alt'" : ""]><td>[name]</td><td>[enclave[name]]</td></tr>"
-			even = !even
-	if(eng.len > 0)
-		dat += "<tr><th colspan=3>Engineering</th></tr>"
-		for(var/name in eng)
-			dat += "<tr[even ? " class='alt'" : ""]><td>[name]</td><td>[eng[name]]</td></tr>"
-			even = !even
-	if(med.len > 0)
-		dat += "<tr><th colspan=3>Medical</th></tr>"
-		for(var/name in med)
-			dat += "<tr[even ? " class='alt'" : ""]><td>[name]</td><td>[med[name]]</td></tr>"
-			even = !even
-	if(sci.len > 0)
-		dat += "<tr><th colspan=3>Science</th></tr>"
-		for(var/name in sci)
-			dat += "<tr[even ? " class='alt'" : ""]><td>[name]</td><td>[sci[name]]</td></tr>"
-			even = !even
-	if(sup.len > 0)
-		dat += "<tr><th colspan=3>Supply</th></tr>"
-		for(var/name in sup)
-			dat += "<tr[even ? " class='alt'" : ""]><td>[name]</td><td>[sup[name]]</td></tr>"
-			even = !even
-	if(civ.len > 0)
-		dat += "<tr><th colspan=3>Civilian</th></tr>"
-		for(var/name in civ)
-			dat += "<tr[even ? " class='alt'" : ""]><td>[name]</td><td>[civ[name]]</td></tr>"
-			even = !even
-	// in case somebody is insane and added them to the manifest, why not
-	if(bot.len > 0)
-		dat += "<tr><th colspan=3>Silicon</th></tr>"
-		for(var/name in bot)
-			dat += "<tr[even ? " class='alt'" : ""]><td>[name]</td><td>[bot[name]]</td></tr>"
 			even = !even
 	// misc guys
 	if(misc.len > 0)

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -75,6 +75,7 @@
 		foundrecord.fields["rank"] = assignment
 
 /datum/datacore/proc/get_manifest(monochrome, OOC)
+	var/list/heads = list()
 	var/list/vault = list()
 	var/list/brotherhood = list()
 	var/list/enclave = list()
@@ -102,6 +103,9 @@
 		var/name = t.fields["name"]
 		var/rank = t.fields["rank"]
 		var/department = 0
+		if(rank in command_positions)
+			heads[name] = rank
+			department = 1
 		if(rank in vault_occupations)
 			vault[name] = rank
 			department = 1
@@ -128,6 +132,11 @@
 			department = 1
 		if(!department && !(name in heads))
 			misc[name] = rank
+	if(heads.len > 0)
+		dat += "<tr><th colspan=3>Heads</th></tr>"
+		for(var/name in heads)
+			dat += "<tr[even ? " class='alt'" : ""]><td>[name]</td><td>[heads[name]]</td></tr>"
+			even = !even
 	if(vault.len > 0)
 		dat += "<tr><th colspan=3>Vault 113</th></tr>"
 		for(var/name in vault)

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -1096,10 +1096,10 @@
 	new /obj/item/ammo_box/magazine/luger(src)
 	new /obj/item/ammo_box/magazine/luger(src)
 	new /obj/item/weapon/gun/ballistic/automatic/pistol/luger(src)
-	
+
 /obj/item/weapon/storage/belt/military/enclavearmy
 	name = "Infantry Belt"
-	desc = "A well-used belt with numerous pouches, designed for experienced soldiers."
+	desc = "A well-used belt with numerous small pouches designed specifically for the storage of microfusion cells. Clearly a belt used by an individual who expects to be reloading an energy weapon frequently."
 	icon_state = "grenadebeltold"
 	item_state = "military"
 	storage_slots = 14
@@ -1112,6 +1112,8 @@
 		/obj/item/weapon/reknife,
 		/obj/item/clothing/glasses/sunglassespaop,
 		/obj/item/clothing/ears/earmuffs,
+		/obj/item/weapon/stock_parts/cell,
+		/obj/item/weapon/stock_parts/cell/high,
 		)
 
 /obj/item/weapon/storage/belt/military/enclavearmy/full/New()
@@ -1121,10 +1123,10 @@
 	new /obj/item/weapon/reknife(src)
 	new /obj/item/clothing/glasses/sunglassespaop(src)
 	new /obj/item/clothing/ears/earmuffs(src)
-	
+
 /obj/item/weapon/storage/belt/military/brotherhoodbelt
 	name = "Combat Belt"
-	desc = "A well-used belt with numerous pouches, designed for experienced soldiers."
+	desc = "A well-used belt with numerous small pouches designed specifically for the storage of microfusion cells. Clearly a belt used by an individual who expects to be reloading an energy weapon frequently."
 	icon_state = "grenadebeltold"
 	item_state = "military"
 	storage_slots = 14
@@ -1137,6 +1139,8 @@
 		/obj/item/weapon/kitchen/knife/combat,
 		/obj/item/clothing/glasses/sunglassespaop,
 		/obj/item/clothing/ears/earmuffs,
+		/obj/item/weapon/stock_parts/cell,
+		/obj/item/weapon/stock_parts/cell/high,
 		)
 
 /obj/item/weapon/storage/belt/military/brotherhoodbelt/full/New()
@@ -1146,7 +1150,7 @@
 	new /obj/item/weapon/kitchen/knife/combat(src)
 	new /obj/item/clothing/glasses/sunglassespaop(src)
 	new /obj/item/clothing/ears/earmuffs(src)
-	
+
 /obj/item/weapon/storage/belt/jakeholster
 	name = "Makeshift holster"
 	desc = "A very raggedy looking holster presumably created from scraps of leather and sisal rope, and crafted to accommodate a large revolver. Seems to have speedloader pouches attached to the belt, for quick access."

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -1096,7 +1096,32 @@
 	new /obj/item/ammo_box/magazine/luger(src)
 	new /obj/item/ammo_box/magazine/luger(src)
 	new /obj/item/weapon/gun/ballistic/automatic/pistol/luger(src)
+	
+/obj/item/weapon/storage/belt/military/enclavearmy
+	name = "Infantry Belt"
+	desc = "A well-used belt with numerous pouches, designed for experienced soldiers."
+	icon_state = "grenadebeltold"
+	item_state = "military"
+	storage_slots = 14
+	w_class = WEIGHT_CLASS_BULKY
+	max_w_class = WEIGHT_CLASS_BULKY
+	max_combined_w_class = 50
+	can_hold = list(
+		/obj/item/weapon/reagent_containers/hypospray/combat,
+		/obj/item/device/radio,
+		/obj/item/weapon/reknife,
+		/obj/item/clothing/glasses/sunglassespaop,
+		/obj/item/clothing/ears/earmuffs,
+		)
 
+/obj/item/weapon/storage/belt/military/enclavearmy/full/New()
+	..()
+	new /obj/item/weapon/reagent_containers/hypospray/combat(src)
+	new /obj/item/device/radio(src)
+	new /obj/item/weapon/reknife(src)
+	new /obj/item/clothing/glasses/sunglassespaop(src)
+	new /obj/item/clothing/ears/earmuffs(src)
+	
 /obj/item/weapon/storage/belt/jakeholster
 	name = "Makeshift holster"
 	desc = "A very raggedy looking holster presumably created from scraps of leather and sisal rope, and crafted to accommodate a large revolver. Seems to have speedloader pouches attached to the belt, for quick access."

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -1122,6 +1122,31 @@
 	new /obj/item/clothing/glasses/sunglassespaop(src)
 	new /obj/item/clothing/ears/earmuffs(src)
 	
+/obj/item/weapon/storage/belt/military/brotherhoodbelt
+	name = "Combat Belt"
+	desc = "A well-used belt with numerous pouches, designed for experienced soldiers."
+	icon_state = "grenadebeltold"
+	item_state = "military"
+	storage_slots = 14
+	w_class = WEIGHT_CLASS_BULKY
+	max_w_class = WEIGHT_CLASS_BULKY
+	max_combined_w_class = 50
+	can_hold = list(
+		/obj/item/weapon/reagent_containers/pill/patch/stimpak,
+		/obj/item/device/radio,
+		/obj/item/weapon/kitchen/knife/combat,
+		/obj/item/clothing/glasses/sunglassespaop,
+		/obj/item/clothing/ears/earmuffs,
+		)
+
+/obj/item/weapon/storage/belt/military/brotherhoodbelt/full/New()
+	..()
+	new /obj/item/weapon/reagent_containers/pill/patch/stimpak(src)
+	new /obj/item/device/radio(src)
+	new /obj/item/weapon/kitchen/knife/combat(src)
+	new /obj/item/clothing/glasses/sunglassespaop(src)
+	new /obj/item/clothing/ears/earmuffs(src)
+	
 /obj/item/weapon/storage/belt/jakeholster
 	name = "Makeshift holster"
 	desc = "A very raggedy looking holster presumably created from scraps of leather and sisal rope, and crafted to accommodate a large revolver. Seems to have speedloader pouches attached to the belt, for quick access."

--- a/code/modules/fallout/misc/jobs/job/brotherhood.dm
+++ b/code/modules/fallout/misc/jobs/job/brotherhood.dm
@@ -60,13 +60,8 @@
 	suit = /obj/item/clothing/suit/f13/elder
 	weapon = /obj/item/weapon/gun/energy/laser/pistol
 	back = /obj/item/weapon/twohanded/eldersword
-	belt = /obj/item/weapon/storage/belt/military/army
+	belt = /obj/item/weapon/storage/belt/military/brotherhoodbelt/full
 	weapon = /obj/item/weapon/gun/energy/laser/rcw
-	belt_contents = list(/obj/item/weapon/reagent_containers/pill/patch/stimpak = 2,
-		  /obj/item/device/radio = 1,
-		  /obj/item/weapon/kitchen/knife/combat = 1,
-		  /obj/item/clothing/ears/earmuffs = 1,
-	   	  /obj/item/clothing/glasses/sunglassespaop = 1)
 	id = /obj/item/weapon/card/id/bos
 
 	//Brotherhood Head Paladin
@@ -126,13 +121,8 @@
 	shoes = /obj/item/clothing/shoes/f13/military
 	suit = /obj/item/clothing/suit/armor/f13/power_armor/t51b
 	head = /obj/item/clothing/head/helmet/power_armor/t51b
-	belt = /obj/item/weapon/storage/belt/military/army
+	belt = /obj/item/weapon/storage/belt/military/brotherhoodbelt/full
 	weapon = null
-	belt_contents = list(/obj/item/weapon/reagent_containers/pill/patch/stimpak = 2,
-		  /obj/item/device/radio = 1,
-		  /obj/item/weapon/kitchen/knife/combat = 1,
-		  /obj/item/clothing/ears/earmuffs = 1,
-		  /obj/item/clothing/glasses/sunglassespaop = 1)
 	id = /obj/item/weapon/card/id/bos
 
 //Head Scribe
@@ -189,11 +179,8 @@
 	suit = /obj/item/clothing/suit/scribe
 	shoes = /obj/item/clothing/shoes/f13/military
 	head = null
-	belt = /obj/item/weapon/storage/belt/military/army
+	belt = /obj/item/weapon/storage/belt/military/brotherhoodbelt/full
 	weapon = /obj/item/weapon/gun/energy/laser/pistol
-	belt_contents = list(/obj/item/weapon/reagent_containers/pill/patch/stimpak = 2,
-	  	/obj/item/device/radio = 1,
-	  	/obj/item/weapon/kitchen/knife/combat = 1)
 	id = /obj/item/weapon/card/id/bos
 
 //Brotherhood Paladin
@@ -252,13 +239,8 @@
 	shoes = /obj/item/clothing/shoes/f13/military
 	suit = /obj/item/clothing/suit/armor/f13/power_armor/t51b
 	head = /obj/item/clothing/head/helmet/power_armor/t51b
-	belt = /obj/item/weapon/storage/belt/military/army
+	belt = /obj/item/weapon/storage/belt/military/brotherhoodbelt/full
 	weapon = null
-	belt_contents = list(/obj/item/weapon/reagent_containers/pill/patch/stimpak = 2,
-	  	/obj/item/device/radio = 1,
-	  	/obj/item/weapon/kitchen/knife/combat = 1,
-	  	/obj/item/clothing/ears/earmuffs = 1,
-	  	/obj/item/clothing/glasses/sunglassespaop = 1)
 	id = /obj/item/weapon/card/id/bos
 
 //Brotherhood Knight
@@ -316,13 +298,8 @@
 	shoes = /obj/item/clothing/shoes/f13/military
 	suit = /obj/item/clothing/suit/armor/f13/power_armor/t45d
 	head = /obj/item/clothing/head/helmet/power_armor/t45d
-	belt = /obj/item/weapon/storage/belt/military/army
+	belt = /obj/item/weapon/storage/belt/military/brotherhoodbelt/full
 	weapon = /obj/item/weapon/gun/energy/laser/rifle
-	belt_contents = list(/obj/item/weapon/reagent_containers/pill/patch/stimpak = 2,
-		  /obj/item/device/radio = 1,
-		  /obj/item/weapon/kitchen/knife/combat = 1,
-		  /obj/item/clothing/ears/earmuffs = 1,
-		  /obj/item/clothing/glasses/sunglassespaop = 1)
 	id = /obj/item/weapon/card/id/bos
 
 //Scribes!!
@@ -379,9 +356,6 @@
 	suit = /obj/item/clothing/suit/scribe
 	shoes = /obj/item/clothing/shoes/f13/military
 	head = null
-	belt = /obj/item/weapon/storage/belt/military/army
+	belt = /obj/item/weapon/storage/belt/military/brotherhoodbelt/full
 	weapon = /obj/item/weapon/gun/energy/laser/pistol
-	belt_contents = list(/obj/item/weapon/reagent_containers/pill/patch/stimpak = 2,
-		  /obj/item/device/radio = 1,
-		  /obj/item/weapon/kitchen/knife/combat = 1)
 	id = /obj/item/weapon/card/id/bos

--- a/code/modules/fallout/misc/jobs/job/enclave.dm
+++ b/code/modules/fallout/misc/jobs/job/enclave.dm
@@ -55,13 +55,8 @@
 	uniform = /obj/item/clothing/under/f13/enclave_officer
 	shoes = /obj/item/clothing/shoes/f13/military
 	suit = /obj/item/clothing/suit/f13/autumn
-	belt = /obj/item/weapon/storage/belt/military/army
+	belt = /obj/item/weapon/storage/belt/military/enclavearmy/full
 	weapon = null
-	belt_contents = list(/obj/item/weapon/reagent_containers/hypospray/combat = 1,
-		  /obj/item/device/radio = 1,
-		  /obj/item/weapon/reknife = 1,
-		  /obj/item/clothing/glasses/sunglassespaop = 1,
-		  /obj/item/clothing/ears/earmuffs = 1)
 	id = /obj/item/weapon/card/id/enclave
 
 //Enclave Lieutenant
@@ -124,13 +119,8 @@
 	shoes = /obj/item/clothing/shoes/f13/military
 	suit = null
 	head = /obj/item/clothing/head/soft/f13/enclave
-	belt = /obj/item/weapon/storage/belt/military/army
+	belt = /obj/item/weapon/storage/belt/military/enclavearmy/full
 	weapon = null
-	belt_contents = list(/obj/item/weapon/reagent_containers/hypospray/combat = 1,
-		  /obj/item/device/radio = 1,
-		  /obj/item/weapon/reknife = 1,
-		  /obj/item/clothing/glasses/sunglassespaop = 1,
-		  /obj/item/clothing/ears/earmuffs = 1)
 	id = /obj/item/weapon/card/id/enclave
 
 //Enclave Private
@@ -189,13 +179,8 @@
 	uniform = /obj/item/clothing/under/f13/dbdu
 	shoes = /obj/item/clothing/shoes/f13/military
 	head = /obj/item/clothing/head/soft/f13/utility/tan
-	belt = /obj/item/weapon/storage/belt/military/army
+	belt = /obj/item/weapon/storage/belt/military/enclavearmy/full
 	weapon = /obj/item/weapon/gun/energy/plasma
-	belt_contents = list(/obj/item/weapon/reagent_containers/hypospray/combat = 1,
-	  	  /obj/item/device/radio = 1,
-		  /obj/item/weapon/reknife = 1,
-		  /obj/item/clothing/glasses/sunglassespaop = 1,
-		  /obj/item/clothing/ears/earmuffs = 1)
 	id = /obj/item/weapon/card/id/enclave
 
 	//Enclave Scientist
@@ -252,13 +237,8 @@
 	uniform = /obj/item/clothing/under/f13/dbdu
 	shoes = /obj/item/clothing/shoes/f13/military
 	head = /obj/item/clothing/head/soft/f13/utility/tan
-	belt = /obj/item/weapon/storage/belt/military/army
+	belt = /obj/item/weapon/storage/belt/military/enclavearmy/full
 	weapon = /obj/item/weapon/gun/energy/plasma
-	belt_contents = list(/obj/item/weapon/reagent_containers/hypospray/combat = 1,
-		  /obj/item/device/radio = 1,
-		  /obj/item/weapon/reknife = 1,
-		  /obj/item/clothing/glasses/sunglassespaop = 1,
-		  /obj/item/clothing/ears/earmuffs = 1)
 	id = /obj/item/weapon/card/id/enclave
 
 
@@ -317,11 +297,6 @@
 	uniform = /obj/item/clothing/under/f13/dbdu
 	shoes = /obj/item/clothing/shoes/f13/military
 	head = /obj/item/clothing/head/soft/f13/utility/tan
-	belt = /obj/item/weapon/storage/belt/military/army
+	belt = /obj/item/weapon/storage/belt/military/enclavearmy/full
 	weapon = /obj/item/weapon/gun/energy/plasma
-	belt_contents = list(/obj/item/weapon/reagent_containers/hypospray/combat = 1,
-		  /obj/item/device/radio = 1,
-		  /obj/item/weapon/reknife = 1,
-	  	  /obj/item/clothing/glasses/sunglassespaop = 1,
-		  /obj/item/clothing/ears/earmuffs = 1)
 	id = /obj/item/weapon/card/id/enclave

--- a/code/modules/fallout/obj/chems.dm
+++ b/code/modules/fallout/obj/chems.dm
@@ -12,7 +12,7 @@
 /obj/item/weapon/reagent_containers/pill/patch/stimpak
 	name = "stimpak"
 	desc = "A stimpak, or stimulation delivery package, is a type of hand-held medication used for healing the body. This item consists of a syringe for containing and delivering the medication and a gauge for measuring the status of the stimpak's contents. When the medicine is injected, it provides immediate healing of the body's minor wounds."
-	list_reagents = list("styptic_powder" = 20, "silver_sulfadiazine" = 20, "oxandrolone" = 5, "stimulants" = 5)
+	list_reagents = list("styptic_powder" = 20, "silver_sulfadiazine" = 20, "salglu_solution" = 15)
 	icon = 'icons/fallout/objects/medicine/syringe.dmi'
 	icon_state = "stim_15"
 	item_state = "syringe_15"
@@ -21,7 +21,7 @@
 /obj/item/weapon/reagent_containers/pill/patch/supstimpak
 	name = "super stimpak"
 	desc = "The super version of the Stimpak has an additional vial containing more powerful drugs than the basic model, as well as a leather belt to strap the needle to the injured limb." // removed morphine from both this and regular stimpacks, they are purely for healing wounds - painkilling is done by med-x.
-	list_reagents = list("styptic_powder" = 50, "silver_sulfadiazine" = 50, "oxandrolone" = 15, "stimulants" = 15, "salglu_solution" = 45)
+	list_reagents = list("styptic_powder" = 40, "silver_sulfadiazine" = 40, "salglu_solution" = 30)
 	icon = 'icons/fallout/objects/medicine/syringe.dmi'
 	icon_state = "superstim_15"
 	item_state = "syringe_15"
@@ -30,7 +30,7 @@
 /obj/item/weapon/reagent_containers/pill/patch/medx
 	name = "med-x"
 	desc = "Med-X is a potent opiate analgesic that binds to opioid receptors in the brain and central nervous system, reducing the perception of pain as well as the emotional response to pain.<br>Essentially, it is a painkiller delivered via hypodermic needle."
-	list_reagents = list("methamphetamine" = 5, "morphine" = 15) // this thing having meth is ok, krokodil not so much. it's basically fallout's version of morphine, not adrenaline.
+	list_reagents = list("muscle stimulant" = 40, "morphine" = 5)
 	icon = 'icons/fallout/objects/medicine/syringe.dmi'
 	icon_state = "medx_15"
 	item_state = "syringe_15"
@@ -48,7 +48,7 @@
 /obj/item/weapon/reagent_containers/pill/patch/jet
 	name = "jet"
 	desc = "Jet is a highly addictive drug first synthesized by Myron. It is extracted from the fumes of brahmin feces and administered via an inhaler."
-	list_reagents = list("stimulants" = 10, "crank" = 6, "krokodil" = 4) // reduced crank component as 10u caused instant addiction, meaning one hit was a guaranteed hook.
+	list_reagents = list("stimulants" = 6, "crank" = 6, "krokodil" = 6) // reduced crank component as 10u caused instant addiction, meaning one hit was a guaranteed hook.
 	icon = 'icons/fallout/objects/medicine/chemical.dmi'
 	icon_state = "jet"
 	item_state = "bandaid"
@@ -57,7 +57,7 @@
 /obj/item/weapon/reagent_containers/pill/patch/psycho
 	name = "psycho"
 	desc = "Psycho will increase damage resistance, allowing subjects to survive hits more easily."
-	list_reagents = list("epinephrine" = 30, "inacusiate" = 10, "oculine" = 10) //increasing this just slightly to make psycho more worth using.
+	list_reagents = list("epinephrine" = 15, "inacusiate" = 10, "oculine" = 10, "muscle stimulant" = 10) //increasing this just slightly to make psycho more worth using.
 	icon = 'icons/fallout/objects/medicine/syringe.dmi'
 	icon_state = "psycho"
 	item_state = "syringe_15"
@@ -75,7 +75,7 @@
 /obj/item/weapon/reagent_containers/pill/patch/turbo
 	name = "turbo"
 	desc = "Turbo appears to be an inhaler of Jet hastily duct-taped to an aerosol can of HairStylez-brand hair spray. Turbo causes brief slowdown of the user's surroundings (time goes at about 35% of its original speed), including everything from enemy movements to projectile speeds (the user's own projectile speed included) to the duration of the drug itself. However, the user does not experience the slowdown - their own movement speed and fire rate will remain the same."
-	list_reagents = list("stimulants" = 3, "methamphetamine" = 3, "crank" = 3) // stims & meth filter out slowly due to server tickrate, this much should last for roughly 4 minutes.
+	list_reagents = list("stimulants" = 5, "methamphetamine" = 5, "crank" = 5) // stims & meth filter out slowly due to server tickrate, this much should last for roughly 4 minutes.
 	icon = 'icons/fallout/objects/medicine/chemical.dmi'
 	icon_state = "turbo"
 	item_state = "turbo"

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -15,7 +15,7 @@
 	materials = list(MAT_METAL=700, MAT_GLASS=50)
 	var/rigged = 0		// true if rigged to explode
 	var/chargerate = 100 //how much power is given every tick in a recharger
-	var/self_recharge = 0 //does it self recharge, over time, or not?
+	var/self_recharge = 1 //does it self recharge, over time, or not?
 	var/ratingdesc = TRUE
 	var/grown_battery = FALSE // If it's a grown that acts as a battery, add a wire overlay to it.
 
@@ -200,7 +200,7 @@
 	name = "high-capacity power cell"
 	origin_tech = "powerstorage=2"
 	icon_state = "hcell"
-	maxcharge = 10000
+	maxcharge = 2250
 	materials = list(MAT_GLASS=60)
 	rating = 3
 	chargerate = 1500

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -54,9 +54,9 @@
 	desc = "A modified air-needle autoinjector, used by support operatives to quickly heal injuries in combat."
 	amount_per_transfer_from_this = 10
 	icon_state = "combat_hypo"
-	volume = 90
+	volume = 150
 	ignore_flags = 1 // So they can heal their comrades.
-	list_reagents = list("epinephrine" = 30, "omnizine" = 30, "leporazine" = 15, "atropine" = 15)
+	list_reagents = list("epinephrine" = 30, "muscle stimulant" = 30, "omnizine" = 30, "leporazine" = 30, "atropine" = 30)
 
 /obj/item/weapon/reagent_containers/hypospray/combat/nanites
 	desc = "A modified air-needle autoinjector for use in combat situations. Prefilled with expensive medical nanites for rapid healing."

--- a/code/modules/research/designs/power_designs.dm
+++ b/code/modules/research/designs/power_designs.dm
@@ -3,26 +3,26 @@
 ////////////////////////////////////////
 
 /datum/design/basic_cell
-	name = "Basic Power Cell"
-	desc = "A basic power cell that holds 1000 units of energy."
+	name = "Standard Microfusion Cell"
+	desc = "A microfusion power cell that holds 1000 units of energy."
 	id = "basic_cell"
 	req_tech = list("powerstorage" = 1)
 	build_type = PROTOLATHE | AUTOLATHE |MECHFAB
 	materials = list(MAT_METAL = 700, MAT_GLASS = 50)
-	construction_time=100
+	construction_time=30
 	build_path = /obj/item/weapon/stock_parts/cell
 	category = list("Misc","Power Designs","Machinery","initial")
 
 /datum/design/high_cell
-	name = "High-Capacity Power Cell"
-	desc = "A power cell that holds 10000 units of energy."
+	name = "Improved Microfusion Cell"
+	desc = "A microfusion power cell that holds 2250 units of energy."
 	id = "high_cell"
-	req_tech = list("powerstorage" = 2)
+	req_tech = list("powerstorage" = 1)
 	build_type = PROTOLATHE | AUTOLATHE | MECHFAB
-	materials = list(MAT_METAL = 700, MAT_GLASS = 60)
-	construction_time=100
+	materials = list(MAT_METAL = 4500, MAT_GLASS = 500)
+	construction_time=30
 	build_path = /obj/item/weapon/stock_parts/cell/high
-	category = list("Misc","Power Designs")
+	category = list("Misc","Power Designs","Machinery","initial")
 
 /datum/design/super_cell
 	name = "Super-Capacity Power Cell"


### PR DESCRIPTION
fixed crew manifest showing jobs under multiple tabs (scientist would show up under enclave & science)

added two new belt items, to give enclave/BoS a belt specifically designed for the purpose of carrying extra power cells. has some default equipment in it too but cannot be used to store items which are not microfusion cells

added these belts to enclave/bos loadouts

reduced the power cell high charge from 10k to 2.25k, ideally use this to replace green powercells on maps since the green cell currently is just a skin, no extra features.

hypospray for enclave has had its chems changed slightly, including muscle stimulant for the ability to resist pain and lesser units of others for a wider variety, half combat stim, half healing item.

high tier power cell has also had its manufacturing cost increased.