### PR TITLE
general changes part 6 chems and claws edition

### DIFF
--- a/code/modules/QuestMachines/faction_bounty_machines.dm
+++ b/code/modules/QuestMachines/faction_bounty_machines.dm
@@ -220,11 +220,11 @@
 	density = 1
 
 	price_list = list(
-					/obj/item/weapon/reagent_containers/pill/patch/stimpak = 150,
-					/obj/item/weapon/reagent_containers/pill/patch/supstimpak = 300,
-					/obj/item/weapon/reagent_containers/pill/patch/medx = 550,
-					/obj/item/weapon/reagent_containers/pill/patch/radaway = 500,
-					/obj/item/weapon/reagent_containers/pill/patch/radx = 600,
+					/obj/item/weapon/reagent_containers/pill/patch/stimpak = 120,
+					/obj/item/weapon/reagent_containers/pill/patch/supstimpak = 250,
+					/obj/item/weapon/reagent_containers/pill/patch/medx = 150,
+					/obj/item/weapon/reagent_containers/pill/patch/radaway = 250,
+					/obj/item/weapon/reagent_containers/pill/patch/radx = 300,
 					)
 
 /* CHEM TRADER */
@@ -239,10 +239,10 @@
 	density = 1
 
 	price_list = list(
-					/obj/item/weapon/reagent_containers/pill/patch/jet = 300,
-					/obj/item/weapon/reagent_containers/pill/patch/psycho = 900,
-					/obj/item/weapon/reagent_containers/pill/patch/turbo = 400,
-					/obj/item/weapon/reagent_containers/pill/patch/medx = 500,
+					/obj/item/weapon/reagent_containers/pill/patch/jet = 250,
+					/obj/item/weapon/reagent_containers/pill/patch/psycho = 400,
+					/obj/item/weapon/reagent_containers/pill/patch/turbo = 350,
+					/obj/item/weapon/reagent_containers/pill/patch/medx = 125,
 					)
 
 

--- a/code/modules/fallout/mob/npc/deathclaw.dm
+++ b/code/modules/fallout/mob/npc/deathclaw.dm
@@ -7,9 +7,9 @@
 	icon_state = "deathclaw"
 	icon_living = "deathclaw"
 	icon_dead = "deathclaw_dead"
+	turns_per_move = 9
 	speed = 2
-	move_to_delay = 4
-	turns_per_move = 5
+	move_to_delay = 2 // this lot makes the deathclaw a LOT faster. if you are wearing even a standard amount of gear, you will not be outrunning this beasty.
 	response_help = "touches"
 	response_disarm = "tries to grab the deathclaw by its large"
 	response_harm = "hits the deathclaw right in its large"
@@ -17,28 +17,28 @@
 	maxHealth = 400
 	health = 400
 	self_weight = 500
-	damage_coeff = list(BRUTE = 0.6, BURN = 0.8, TOX = 0.2, CLONE = 0, STAMINA = 1, OXY = 0)
+	damage_coeff = list(BRUTE = 0.25, BURN = 0.75, TOX = 0, CLONE = 0, STAMINA = 0, OXY = 0)
 
 	faction = list("hostile", "deathclaw")
 
 	//ambient_sound = 'sound/f13npc/deathclaw_loop.ogg'
 
-	sound_speak_chance = 5
+	sound_speak_chance = 15
 	sound_speak = list('sound/f13npc/deathclaw_charge1.ogg','sound/f13npc/deathclaw_charge2.ogg','sound/f13npc/deathclaw_charge3.ogg')
 
-	aggro_sound_chance = 50
+	aggro_sound_chance = 100
 	aggro_sound = 'sound/f13npc/deathclaw_charge1.ogg'
 
 	death_sound = 'sound/f13npc/deathclaw_death.ogg'
 
 	environment_smash = 3 // YOU CAN'T HIDE FROM ME
 	force_threshold = 15
-	melee_damage_lower = 25
-	armour_penetration = 40
+	melee_damage_lower = 30
+	armour_penetration = 70
 	melee_damage_upper = 40
-	aggro_vision_range = 12
-	see_in_dark = 8
-	idle_vision_range = 7
+	aggro_vision_range = 14
+	see_in_dark = 10
+	idle_vision_range = 10
 	pixel_w = -16
 	mob_size = MOB_SIZE_LARGE
 	attacktext = "slashes"

--- a/code/modules/fallout/obj/chems.dm
+++ b/code/modules/fallout/obj/chems.dm
@@ -21,7 +21,7 @@
 /obj/item/weapon/reagent_containers/pill/patch/supstimpak
 	name = "super stimpak"
 	desc = "The super version of the Stimpak has an additional vial containing more powerful drugs than the basic model. Can cause diziness if too many super stimpaks are used in a short timespan."
-	list_reagents = list("styptic_powder" = 15, "silver_sulfadiazine" = 15, "salglu_solution" = 10, "omnizine" = 5, "mine_salve" = 5) // miners salve causes some hud distortion, and at higher units increases this exponetnially, should add a drawback so people dont just pop superstimms constantly
+	list_reagents = list("styptic_powder" = 15, "silver_sulfadiazine" = 15, "salglu_solution" = 10, "omnizine" = 8, "mine_salve" = 2) // miners salve causes some hud distortion, and at higher units increases this exponentially, should add a drawback so people dont just pop superstimms constantly
 	icon = 'icons/fallout/objects/medicine/syringe.dmi'
 	icon_state = "superstim_15"
 	item_state = "syringe_15"

--- a/code/modules/fallout/obj/chems.dm
+++ b/code/modules/fallout/obj/chems.dm
@@ -74,7 +74,7 @@
 
 /obj/item/weapon/reagent_containers/pill/patch/turbo
 	name = "turbo"
-	desc = "Turbo provides a speed boost to the user, though mixing this many chems can't be good for your health."
+	desc = "Turbo provides a speed boost to the user, though mixing volatile chems like this can't be good for your health."
 	list_reagents = list("hyperepinephrine" = 16, "crank" = 9)
 	icon = 'icons/fallout/objects/medicine/chemical.dmi'
 	icon_state = "turbo"

--- a/code/modules/fallout/obj/chems.dm
+++ b/code/modules/fallout/obj/chems.dm
@@ -3,7 +3,7 @@
 /obj/item/weapon/reagent_containers/pill/patch/healingpowder
 	name = "healing powder"
 	desc = "A foul-smelling primitive healing medicine.<br>It is widespread in the wasteland due to easy production - all kinds of Wastelanders from Settlers to Mercenaries use it to heal minor injuries.<br>Soldiers of the Legion use healing powder as their primary source of medicine and healing, since the Legion bans the use of other chems, such as stimpaks."
-	list_reagents = list("omnizine" = 15, "salglu_solution" = 10, "morphine" = 4.5, "musclestimulant" = 5) // added morphine to the mix to prevent stacking a bunch of healing powders together, and to add the drowsiness drawback from FO2.
+	list_reagents = list("omnizine" = 15, "salglu_solution" = 10, "morphine" = 4.5, "musclestimulant" = 2) // added morphine to the mix to prevent stacking a bunch of healing powders together, and to add the drowsiness drawback from FO2.
 	icon = 'icons/fallout/objects/medicine/chemical.dmi'
 	icon_state = "heal_powder"
 	item_state = "bandaid"

--- a/code/modules/fallout/obj/chems.dm
+++ b/code/modules/fallout/obj/chems.dm
@@ -20,7 +20,7 @@
 
 /obj/item/weapon/reagent_containers/pill/patch/supstimpak
 	name = "super stimpak"
-	desc = "The super version of the Stimpak has an additional vial containing more powerful drugs than the basic model."
+	desc = "The super version of the Stimpak has an additional vial containing more powerful drugs than the basic model. Can cause diziness if too many super stimpaks are used in a short timespan."
 	list_reagents = list("styptic_powder" = 15, "silver_sulfadiazine" = 15, "salglu_solution" = 10, "omnizine" = 5, "mine_salve" = 5) // miners salve causes some hud distortion, and at higher units increases this exponetnially, should add a drawback so people dont just pop superstimms constantly
 	icon = 'icons/fallout/objects/medicine/syringe.dmi'
 	icon_state = "superstim_15"

--- a/code/modules/fallout/obj/chems.dm
+++ b/code/modules/fallout/obj/chems.dm
@@ -3,7 +3,7 @@
 /obj/item/weapon/reagent_containers/pill/patch/healingpowder
 	name = "healing powder"
 	desc = "A foul-smelling primitive healing medicine.<br>It is widespread in the wasteland due to easy production - all kinds of Wastelanders from Settlers to Mercenaries use it to heal minor injuries.<br>Soldiers of the Legion use healing powder as their primary source of medicine and healing, since the Legion bans the use of other chems, such as stimpaks."
-	list_reagents = list("omnizine" = 15, "salglu_solution" = 10) // slight reduction in omnizine content as it metabolizes very slowly, 15u can last like 10 minutes.
+	list_reagents = list("omnizine" = 15, "salglu_solution" = 10, "morphine" = 4.5, "musclestimulant" = 5) // added morphine to the mix to prevent stacking a bunch of healing powders together, and to add the drowsiness drawback from FO2.
 	icon = 'icons/fallout/objects/medicine/chemical.dmi'
 	icon_state = "heal_powder"
 	item_state = "bandaid"
@@ -11,8 +11,8 @@
 
 /obj/item/weapon/reagent_containers/pill/patch/stimpak
 	name = "stimpak"
-	desc = "A stimpak, or stimulation delivery package, is a type of hand-held medication used for healing the body. This item consists of a syringe for containing and delivering the medication and a gauge for measuring the status of the stimpak's contents. When the medicine is injected, it provides immediate healing of the body's minor wounds."
-	list_reagents = list("styptic_powder" = 20, "silver_sulfadiazine" = 20, "salglu_solution" = 15)
+	desc = "A stimpak, or stimulation delivery package, is a type of hand-held medication used for healing the body. Deals minor toxin damage due to contaminants from exposure to the elements."
+	list_reagents = list("styptic_powder" = 10, "silver_sulfadiazine" = 10, "salglu_solution" = 10, "aranesp" = 1.2)
 	icon = 'icons/fallout/objects/medicine/syringe.dmi'
 	icon_state = "stim_15"
 	item_state = "syringe_15"
@@ -20,8 +20,8 @@
 
 /obj/item/weapon/reagent_containers/pill/patch/supstimpak
 	name = "super stimpak"
-	desc = "The super version of the Stimpak has an additional vial containing more powerful drugs than the basic model, as well as a leather belt to strap the needle to the injured limb." // removed morphine from both this and regular stimpacks, they are purely for healing wounds - painkilling is done by med-x.
-	list_reagents = list("styptic_powder" = 40, "silver_sulfadiazine" = 40, "salglu_solution" = 30)
+	desc = "The super version of the Stimpak has an additional vial containing more powerful drugs than the basic model. Deals minor toxin damage due to contaminants from exposure to the elements."
+	list_reagents = list("styptic_powder" = 15, "silver_sulfadiazine" = 15, "salglu_solution" = 10, "omnizine" = 5, "mine_salve" = 4, "aranesp" = 1) // miners salve causes some hud distortion, and at higher units increases this exponetnially, should add a drawback so people dont just pop superstimms constantly
 	icon = 'icons/fallout/objects/medicine/syringe.dmi'
 	icon_state = "superstim_15"
 	item_state = "syringe_15"
@@ -29,8 +29,8 @@
 
 /obj/item/weapon/reagent_containers/pill/patch/medx
 	name = "med-x"
-	desc = "Med-X is a potent opiate analgesic that binds to opioid receptors in the brain and central nervous system, reducing the perception of pain as well as the emotional response to pain.<br>Essentially, it is a painkiller delivered via hypodermic needle."
-	list_reagents = list("morphine" = 5)
+	desc = "Med-X is a potent opiate analgesic that binds to opioid receptors in the brain and central nervous system, reducing the perception of pain as well as the emotional response to pain.<br>Essentially, it is a painkiller delivered via hypodermic needle. Allows a user to walk on despite horrific wounds."
+	list_reagents = list("morphine" = 5, "musclestimulant" = 25)
 	icon = 'icons/fallout/objects/medicine/syringe.dmi'
 	icon_state = "medx_15"
 	item_state = "syringe_15"
@@ -47,8 +47,8 @@
 
 /obj/item/weapon/reagent_containers/pill/patch/jet
 	name = "jet"
-	desc = "Jet is a highly addictive drug first synthesized by Myron. It is extracted from the fumes of brahmin feces and administered via an inhaler."
-	list_reagents = list("stimulants" = 6, "crank" = 6, "krokodil" = 6) // reduced crank component as 10u caused instant addiction, meaning one hit was a guaranteed hook.
+	desc = "Jet is an extremely addictive chem, a single hit is enough to form an addiction in most people. It significantly boosts a user's metabolism, allowing for bursts of increased speed and a quicker recovery time from both fatigue and stuns."
+	list_reagents = list("hyperepinephrine" = 12, "crank" = 12)
 	icon = 'icons/fallout/objects/medicine/chemical.dmi'
 	icon_state = "jet"
 	item_state = "bandaid"
@@ -56,17 +56,17 @@
 
 /obj/item/weapon/reagent_containers/pill/patch/psycho
 	name = "psycho"
-	desc = "Psycho will increase damage resistance, allowing subjects to survive hits more easily."
-	list_reagents = list("epinephrine" = 15, "inacusiate" = 10, "oculine" = 10) //increasing this just slightly to make psycho more worth using.
+	desc = "Psycho boosts pain tolerance and strength to incredible levels, preventing wounds from slowing down the user. It also provides a mixture of stimulants which promote rapid wound healing."
+	list_reagents = list("epinephrine" = 9, "inacusiate" = 8, "oculine" = 8, "psychocorazine" = 25)
 	icon = 'icons/fallout/objects/medicine/syringe.dmi'
 	icon_state = "psycho"
 	item_state = "syringe_15"
 	self_weight = 0.01
-
+	
 /obj/item/weapon/reagent_containers/pill/patch/radx
 	name = "rad-x"
 	desc = "Rad-X is an anti-radiation chemical that can significantly reduce the danger of irradiated areas."
-	list_reagents = list("potass_iodide" = 30, "pen_acid" = 9)
+	list_reagents = list("potass_iodide" = 30, "pen_acid" = 8)
 	icon = 'icons/fallout/objects/medicine/chemical.dmi'
 	icon_state = "radx"
 	item_state = "bandaid"
@@ -74,8 +74,8 @@
 
 /obj/item/weapon/reagent_containers/pill/patch/turbo
 	name = "turbo"
-	desc = "Turbo appears to be an inhaler of Jet hastily duct-taped to an aerosol can of HairStylez-brand hair spray. Turbo causes brief slowdown of the user's surroundings (time goes at about 35% of its original speed), including everything from enemy movements to projectile speeds (the user's own projectile speed included) to the duration of the drug itself. However, the user does not experience the slowdown - their own movement speed and fire rate will remain the same."
-	list_reagents = list("stimulants" = 5, "methamphetamine" = 5, "crank" = 5) // stims & meth filter out slowly due to server tickrate, this much should last for roughly 4 minutes.
+	desc = "Turbo provides a speed boost to the user, though mixing this many chems can't be good for your health."
+	list_reagents = list("hyperepinephrine" = 16, "crank" = 9)
 	icon = 'icons/fallout/objects/medicine/chemical.dmi'
 	icon_state = "turbo"
 	item_state = "turbo"

--- a/code/modules/fallout/obj/chems.dm
+++ b/code/modules/fallout/obj/chems.dm
@@ -20,8 +20,8 @@
 
 /obj/item/weapon/reagent_containers/pill/patch/supstimpak
 	name = "super stimpak"
-	desc = "The super version of the Stimpak has an additional vial containing more powerful drugs than the basic model. Deals minor toxin damage due to contaminants from exposure to the elements."
-	list_reagents = list("styptic_powder" = 15, "silver_sulfadiazine" = 15, "salglu_solution" = 10, "omnizine" = 5, "mine_salve" = 4, "aranesp" = 1) // miners salve causes some hud distortion, and at higher units increases this exponetnially, should add a drawback so people dont just pop superstimms constantly
+	desc = "The super version of the Stimpak has an additional vial containing more powerful drugs than the basic model."
+	list_reagents = list("styptic_powder" = 15, "silver_sulfadiazine" = 15, "salglu_solution" = 10, "omnizine" = 5, "mine_salve" = 5) // miners salve causes some hud distortion, and at higher units increases this exponetnially, should add a drawback so people dont just pop superstimms constantly
 	icon = 'icons/fallout/objects/medicine/syringe.dmi'
 	icon_state = "superstim_15"
 	item_state = "syringe_15"

--- a/code/modules/fallout/obj/chems.dm
+++ b/code/modules/fallout/obj/chems.dm
@@ -48,7 +48,7 @@
 /obj/item/weapon/reagent_containers/pill/patch/jet
 	name = "jet"
 	desc = "Jet is an extremely addictive chem, a single hit is enough to form an addiction in most people. It significantly boosts a user's metabolism, allowing for bursts of increased speed and a quicker recovery time from both fatigue and stuns."
-	list_reagents = list("hyperepinephrine" = 12, "crank" = 12)
+	list_reagents = list("hyperepinephrine" = 9, "crank" = 12)
 	icon = 'icons/fallout/objects/medicine/chemical.dmi'
 	icon_state = "jet"
 	item_state = "bandaid"

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -1,5 +1,5 @@
 /obj/item/weapon/stock_parts/cell
-	name = "power cell"
+	name = "Microfusion cell"
 	desc = "A rechargable electrochemical power cell."
 	icon = 'icons/obj/power.dmi'
 	icon_state = "cell"
@@ -14,8 +14,8 @@
 	var/maxcharge = 1000
 	materials = list(MAT_METAL=700, MAT_GLASS=50)
 	var/rigged = 0		// true if rigged to explode
-	var/chargerate = 100 //how much power is given every tick in a recharger
-	var/self_recharge = 1 //does it self recharge, over time, or not?
+	var/chargerate = 250 //how much power is given every tick in a recharger
+	var/self_recharge = 0 //does it self recharge, over time, or not?
 	var/ratingdesc = TRUE
 	var/grown_battery = FALSE // If it's a grown that acts as a battery, add a wire overlay to it.
 
@@ -197,13 +197,14 @@
 	maxcharge = 2000
 
 /obj/item/weapon/stock_parts/cell/high
-	name = "high-capacity power cell"
-	origin_tech = "powerstorage=2"
+	name = "high-capacity Microfusion cell"
+	origin_tech = "powerstorage=1"
 	icon_state = "hcell"
 	maxcharge = 2250
-	materials = list(MAT_GLASS=60)
+	materials = list(MAT_METAL = 25000, MAT_GLASS = 25000)
 	rating = 3
-	chargerate = 1500
+	chargerate = 250
+	self_recharge = 1
 
 /obj/item/weapon/stock_parts/cell/high/plus
 	name = "high-capacity power cell+"

--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -219,7 +219,7 @@
 	icon_state = "blshell"
 	caliber = "shotgun"
 	projectile_type = /obj/item/projectile/bullet
-	materials = list(MAT_METAL=4000)
+	materials = list(MAT_METAL=250)
 
 
 /obj/item/ammo_casing/shotgun/buckshot
@@ -245,7 +245,7 @@
 	projectile_type = /obj/item/projectile/bullet/rpellet
 	pellets = 6
 	variance = 25
-	materials = list(MAT_METAL=4000)
+	materials = list(MAT_METAL=250)
 
 
 /obj/item/ammo_casing/shotgun/beanbag

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -438,24 +438,24 @@ var/const/INJECT = 5 //injection
 				check_gofast(my_atom)
 				check_goreallyfast(my_atom)
 	return 1
-
+	
 /datum/reagents/proc/check_ignoreslow(mob/M)
 	if(istype(M, /mob))
-		if(M.reagents.has_reagent("morphine")||M.reagents.has_reagent("ephedrine"))
+		if(M.reagents.has_reagent("morphine")||M.reagents.has_reagent("ephedrine")||M.reagents.has_reagent("musclestimulant")||M.reagents.has_reagent("psychocorazine"))
 			return 1
 		else
 			M.status_flags &= ~IGNORESLOWDOWN
 
 /datum/reagents/proc/check_gofast(mob/M)
 	if(istype(M, /mob))
-		if(M.reagents.has_reagent("unholywater")||M.reagents.has_reagent("nuka_cola")||M.reagents.has_reagent("stimulants"))
+		if(M.reagents.has_reagent("unholywater")||M.reagents.has_reagent("nuka_cola")||M.reagents.has_reagent("stimulants")||M.reagents.has_reagent("methamphetamine")||M.reagents.has_reagent("hyperepinephrine"))
 			return 1
 		else
 			M.status_flags &= ~GOTTAGOFAST
 
 /datum/reagents/proc/check_goreallyfast(mob/M)
 	if(istype(M, /mob))
-		if(M.reagents.has_reagent("methamphetamine"))
+		if(M.reagents.has_reagent("PLACEHOLDER")) // no chems use this flag at the moment, because it's too fast.
 			return 1
 		else
 			M.status_flags &= ~GOTTAGOREALLYFAST

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -48,13 +48,14 @@
 	. = 1
 
 /datum/reagent/drug/crank
-	name = "Crank"
+	name = "Jet Fumes"
 	id = "crank"
 	description = "Reduces stun times by about 200%. If overdosed or addicted it will deal significant Toxin, Brute and Brain damage."
 	reagent_state = LIQUID
 	color = "#FA00C8"
-	overdose_threshold = 20
-	addiction_threshold = 10
+	overdose_threshold = 15 // decreased slightly so you you shouldn't take more than one hit of jet every so often.
+	addiction_threshold = 12
+	metabolization_rate = 0.4
 
 /datum/reagent/drug/crank/on_mob_life(mob/living/M)
 	var/high_message = pick("You feel jittery.", "You feel like you gotta go fast.", "You feel like you need to step it up.")
@@ -153,7 +154,7 @@
 	color = "#FAFAFA"
 	overdose_threshold = 20
 	addiction_threshold = 10
-	metabolization_rate = 0.75 * REAGENTS_METABOLISM
+	metabolization_rate = 1.25 * REAGENTS_METABOLISM
 
 /datum/reagent/drug/methamphetamine/on_mob_life(mob/living/M)
 	var/high_message = pick("You feel hyper.", "You feel like you need to go faster.", "You feel like you can run the world.")
@@ -163,7 +164,7 @@
 	M.AdjustStunned(-2, 0)
 	M.AdjustWeakened(-2, 0)
 	M.adjustStaminaLoss(-2, 0)
-	M.status_flags |= GOTTAGOREALLYFAST
+	M.status_flags |= GOTTAGOFAST
 	M.Jitter(2)
 	M.adjustBrainLoss(0.25)
 	if(prob(5))
@@ -317,15 +318,12 @@
 	description = "Amps you up and gets you going, fixes all stamina damage you might have but can cause toxin and oxygen damage.."
 	reagent_state = LIQUID
 	color = "#78FFF0"
+	metabolization_rate = 0.6
 
 /datum/reagent/drug/aranesp/on_mob_life(mob/living/M)
 	var/high_message = pick("You feel amped up.", "You feel ready.", "You feel like you can push it to the limit.")
-	if(prob(5))
-		to_chat(M, "<span class='notice'>[high_message]</span>")
-	M.adjustStaminaLoss(-18, 0)
-	M.adjustToxLoss(0.5, 0)
 	if(prob(50))
-		M.losebreath++
-		M.adjustOxyLoss(1, 0)
+		to_chat(M, "<span class='notice'>[high_message]</span>")
+	M.adjustToxLoss(2, 0)
 	..()
 	. = 1

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1143,7 +1143,7 @@
 
 /datum/reagent/medicine/hyperepinephrine/on_mob_life(mob/living/M as mob)
 	M.status_flags |= GOTTAGOFAST
-	M.adjustToxLoss(2, 0)
+	M.adjustToxLoss(0.7, 0)
 	. = 1
 	..()
 	

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1143,7 +1143,7 @@
 
 /datum/reagent/medicine/hyperepinephrine/on_mob_life(mob/living/M as mob)
 	M.status_flags |= GOTTAGOFAST
-	M.adjustToxLoss(0.7, 0)
+	M.adjustToxLoss(0.5, 0)
 	. = 1
 	..()
 	

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1029,7 +1029,7 @@
 	description = "The active chemical in psycho, significantly boosts the user's tolerance for pain and overall endurance."
 	reagent_state = SOLID
 	color = "#555555"
-	metabolization_rate = 0.325
+	metabolization_rate = 0.6
 
 /datum/reagent/medicine/psychocorazine/on_mob_life(mob/living/M)
 	M.adjustBruteLoss(-0.5*REM, 0)
@@ -1153,7 +1153,7 @@
 	description = "A cocktail of stimulants targeted at the cardiovascular system, allowing for significantly improved pain endurance and recovery from fatigue."
 	reagent_state = LIQUID
 	color = "#A9FBFB"
-	metabolization_rate = 0.175
+	metabolization_rate = 0.18
 
 /datum/reagent/medicine/musclestimulant/on_mob_life(mob/living/M)
 	M.status_flags |= IGNORESLOWDOWN

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -263,7 +263,7 @@
 	description = "Has a 33% chance per metabolism cycle to heal brute and burn damage.  Can be used as a blood substitute on an IV drip."
 	reagent_state = LIQUID
 	color = "#DCDCDC"
-	metabolization_rate = 0.5 * REAGENTS_METABOLISM
+	metabolization_rate = 0.15 * REAGENTS_METABOLISM
 
 /datum/reagent/medicine/salglu_solution/on_mob_life(mob/living/M)
 	if(prob(33))
@@ -496,7 +496,7 @@
 	description = "Increases stun resistance and movement speed. Overdose deals toxin damage and inhibits breathing."
 	reagent_state = LIQUID
 	color = "#D2FFFA"
-	metabolization_rate = 0.5 * REAGENTS_METABOLISM
+	metabolization_rate = 1.5 * REAGENTS_METABOLISM // upped drain slightly
 	overdose_threshold = 45
 	addiction_threshold = 30
 
@@ -1014,6 +1014,36 @@
 	M.adjustCloneLoss(-3*REM, 0)
 	..()
 	. = 1
+	
+/datum/reagent/medicine/tricordrazine/overdose_process(mob/living/M)
+	M.adjustToxLoss(2*REM, 0)
+	M.adjustOxyLoss(2*REM, 0)
+	M.adjustBruteLoss(2*REM, 0)
+	M.adjustFireLoss(2*REM, 0)
+	..()
+	. = 1
+
+/datum/reagent/medicine/psychocorazine
+	name = "Psychocorazine"
+	id = "psychocorazine"
+	description = "The active chemical in psycho, significantly boosts the user's tolerance for pain and overall endurance."
+	reagent_state = SOLID
+	color = "#555555"
+	metabolization_rate = 0.325
+
+/datum/reagent/medicine/psychocorazine/on_mob_life(mob/living/M)
+	M.adjustBruteLoss(-0.5*REM, 0)
+	M.adjustFireLoss(-0.5*REM, 0)
+	M.adjustOxyLoss(-7, 0)
+	M.adjustBrainLoss(-7*REM)
+	M.adjustToxLoss(-0.5*REM, 0)
+	M.AdjustParalysis(-3, 0)
+	M.AdjustStunned(-3, 0)
+	M.AdjustWeakened(-3, 0)
+	M.adjustStaminaLoss(-5*REM, 0)
+	M.status_flags |= IGNORESLOWDOWN
+	..()
+	. = 1
 
 /datum/reagent/medicine/earthsblood //Created by ambrosia gaia plants
 	name = "Earthsblood"
@@ -1084,35 +1114,52 @@
 	. = 1
 
 //used for changeling's adrenaline power
-/datum/reagent/medicine/changelingAdrenaline
-	name = "Adrenaline"
-	id = "changelingAdrenaline"
+/datum/reagent/medicine/adrenaline_cocktail
+	name = "Adrenaline Cocktail"
+	id = "adrenaline_cocktail"
 	description = "Reduces stun times. Also deals toxin damage at high amounts."
 	color = "#C8A5DC"
 	overdose_threshold = 30
 
-/datum/reagent/medicine/changelingAdrenaline/on_mob_life(mob/living/M as mob)
-	M.AdjustParalysis(-1, 0)
-	M.AdjustStunned(-1, 0)
-	M.AdjustWeakened(-1, 0)
-	M.adjustStaminaLoss(-1, 0)
+/datum/reagent/medicine/adrenaline_cocktail/on_mob_life(mob/living/M as mob)
+	M.AdjustParalysis(-2, 0)
+	M.AdjustStunned(-2, 0)
+	M.AdjustWeakened(-2, 0)
+	M.adjustStaminaLoss(-2, 0)
 	. = 1
 	..()
 
-/datum/reagent/medicine/changelingAdrenaline/overdose_process(mob/living/M as mob)
+/datum/reagent/medicine/adrenaline_cocktail/overdose_process(mob/living/M as mob)
 	M.adjustToxLoss(1, 0)
 	. = 1
 	..()
 
-/datum/reagent/medicine/changelingAdrenaline2
-	name = "Adrenaline"
-	id = "changelingAdrenaline2"
-	description = "Drastically increases movement speed."
+/datum/reagent/medicine/hyperepinephrine
+	name = "Hyperepinephrine Solution"
+	id = "hyperepinephrine"
+	description = "Drastically increases oxygen and blood movement through the body, allowing increased movement speeds without fatigue."
 	color = "#C8A5DC"
-	metabolization_rate = 1
+	metabolization_rate = 0.7
 
-/datum/reagent/medicine/changelingAdrenaline2/on_mob_life(mob/living/M as mob)
-	M.status_flags |= GOTTAGOREALLYFAST
+/datum/reagent/medicine/hyperepinephrine/on_mob_life(mob/living/M as mob)
+	M.status_flags |= GOTTAGOFAST
 	M.adjustToxLoss(2, 0)
+	. = 1
+	..()
+	
+/datum/reagent/medicine/musclestimulant
+	name = "Muscle Stimulant"
+	id = "musclestimulant"
+	description = "A cocktail of stimulants targeted at the cardiovascular system, allowing for significantly improved pain endurance and recovery from fatigue."
+	reagent_state = LIQUID
+	color = "#A9FBFB"
+	metabolization_rate = 0.175
+
+/datum/reagent/medicine/musclestimulant/on_mob_life(mob/living/M)
+	M.status_flags |= IGNORESLOWDOWN
+	M.AdjustParalysis(-3, 0)
+	M.AdjustStunned(-3, 0)
+	M.AdjustWeakened(-3, 0)
+	M.adjustStaminaLoss(-2.5*REM, 0)
 	. = 1
 	..()

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -51,12 +51,12 @@
 
 /obj/item/weapon/reagent_containers/hypospray/combat
 	name = "combat stimulant injector"
-	desc = "A modified air-needle autoinjector, used by support operatives to quickly heal injuries in combat."
-	amount_per_transfer_from_this = 10
+	desc = "A modified air-needle autoinjector, cutting edge Enclave technology designed for the rapid application of a chemical cocktail designed to keep a soldier on his feet and in the fight through horrific injuries. The label on the side says not to inject more than once every ten minutes to avoid overdose."
+	amount_per_transfer_from_this = 100
 	icon_state = "combat_hypo"
-	volume = 150
+	volume = 600
 	ignore_flags = 1 // So they can heal their comrades.
-	list_reagents = list("epinephrine" = 30, "omnizine" = 30, "leporazine" = 30, "atropine" = 30)
+	list_reagents = list("musclestimulant" = 140, "psychocorazine" = 140, "epinephrine" = 140, "mannitol" = 60, "oculine" = 60, "inacusiate" = 60)
 
 /obj/item/weapon/reagent_containers/hypospray/combat/nanites
 	desc = "A modified air-needle autoinjector for use in combat situations. Prefilled with expensive medical nanites for rapid healing."

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -51,7 +51,7 @@
 
 /obj/item/weapon/reagent_containers/hypospray/combat
 	name = "combat stimulant injector"
-	desc = "A modified air-needle autoinjector, cutting edge Enclave technology designed for the rapid application of a chemical cocktail designed to keep a soldier on his feet and in the fight through horrific injuries. The label on the side says not to inject more than once every ten minutes to avoid overdose."
+	desc = "A modified air-needle autoinjector, cutting edge Enclave technology for the rapid application of a chemical cocktail designed to keep a soldier on his feet and in the fight despite horrific injuries. The label on the side says not to inject more than once every ten minutes to avoid overdose."
 	amount_per_transfer_from_this = 100
 	icon_state = "combat_hypo"
 	volume = 600

--- a/code/modules/research/designs/power_designs.dm
+++ b/code/modules/research/designs/power_designs.dm
@@ -4,7 +4,7 @@
 
 /datum/design/basic_cell
 	name = "Standard Microfusion Cell"
-	desc = "A microfusion power cell that holds 1000 units of energy."
+	desc = "A Microfusion power cell that holds 1000 units of energy."
 	id = "basic_cell"
 	req_tech = list("powerstorage" = 1)
 	build_type = PROTOLATHE | AUTOLATHE |MECHFAB
@@ -14,12 +14,12 @@
 	category = list("Misc","Power Designs","Machinery","initial")
 
 /datum/design/high_cell
-	name = "Improved Microfusion Cell"
-	desc = "A microfusion power cell that holds 2250 units of energy."
+	name = "Improved Capacity Microfusion Cell"
+	desc = "An improved capacity Microfusion power cell that holds 2250 units of energy."
 	id = "high_cell"
 	req_tech = list("powerstorage" = 1)
 	build_type = PROTOLATHE | AUTOLATHE | MECHFAB
-	materials = list(MAT_METAL = 4500, MAT_GLASS = 500)
+	materials = list(MAT_METAL = 25000, MAT_GLASS = 25000)
 	construction_time=30
 	build_path = /obj/item/weapon/stock_parts/cell/high
 	category = list("Misc","Power Designs","Machinery","initial")


### PR DESCRIPTION
**Added three new chemicals:**
Psychocorazine, provides immunity to wound slowdown, stun resistance, weakening resistance and general movement impairment resistance while in the bloodstream as well as minor healing. Filters out of the body rather quickly.

Muscle stimulants, provides increased stun recovery and immunity to wound slowdown. Filters out of the body rather slowly.

Hyperepinephrine, provides a speed boost but deals toxin damage while in the bloodstream.

Crank has now been renamed Jet Fumes, it still provides 200% stun time reduction and addiction threshold boosted from 10 to 12, overdose sits at 15 though so taking two hits of something with 8+ units of Jet Fumes in it can result in rather nasty side effects. Consume your chems in moderation!

Adjusted Enclave combat stim injector to have a higher quantity of chemicals and volume of chemicals per injection, to distribute an equal share of chems at once. Should make it both less and more useful, less sustainability, more burst effectiveness.

Boosted deathclaw movement speed significantly, it's no longer an enemy you can kite without the help of movement speed enhancing chems or a seriously light overall carryweight. You will have to start firing as soon as you see it, and hope you've got the firepower to bring it down before it closes the distance. Alternatively, get some friends before trying to take on these oversized lizards.

Removed self charging property from regular power cells - this was a mistake on my end. It's intended for higher tier microfusion cells that can be found on the map or printed with later research.

Added self charging property to high capacity power cells. Also increased their manufacturing cost once researched (research is not in yet)

Healing Powder has had its makeup changed slightly, reducing the amount of healing chems per just slightly as ominizine is very long lasting and adding morphine into the mix, to simulate the drowsyness healing powder is meant to cause according to Fallout 2. No more stacking healing powder applications at the legion base for long term heals, take your medicine responsibly!

To offset the above change for healing powder, so that NCR/Legion combat isn't hit too harshly, stimpaks now apply a contaminant chemical which deals minor toxin damage. You'll heal all your physical ailments no problem but intravenous damage from contaminants on the syringe... Don't shoot up with needles you just found lying around in an irradiated wasteland! x)

Med-X no longer gives a speed boost, but does now allow the user to ignore wound slowdown. It still has morphine as part of its makeup, so too much will put you to sleep. This is simply a change as an opioid should not be stimulating muscles to move faster, only relaxing them.

Reduced medical supply/chem costs from vendor just slightly to offset new chem balance, stimpaks heal less but are cheaper though come with side effects, superstims provide more healing but cost more compared to regular stims.

Reduced metal gain from breaking down shotgun shells in an autolathe, some shells were giving 4k metal resource despite only costing 250 to manufacture. This has been fixed.
