### PR TITLE
General changes part 6

### DIFF
--- a/code/datums/martial.dm
+++ b/code/datums/martial.dm
@@ -746,5 +746,29 @@
 		return ..()
 	return 0
 
+
+
+
+
+
+
+
 /datum/martial_art/patraining
 	name = "Power Armor Training"
+
+/obj/item/weapon/pa_manual
+	name = "power armour manual"
+	desc = "A small, black notebook with a warning sign printed on the front. The notebook itself describes how to safely operate power armour without suffering serious injury or death."
+	icon = 'icons/obj/library.dmi'
+	icon_state ="notebook_warning"
+
+/obj/item/weapon/pa_manual/attack_self(mob/living/carbon/human/user)
+	if(!istype(user) || !user)
+		return
+	to_chat(user, "<span class='boldannounce'>You have learned how to safely operate power armour.</span>")
+	var/datum/martial_art/patraining/D = new(null)
+	D.teach(user)
+	user.drop_item()
+	visible_message("<span class='warning'>[src] beeps ominously, and a moment later it bursts up in flames.</span>")
+	new /obj/effect/decal/cleanable/ash(get_turf(src))
+	qdel(src)

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -330,6 +330,7 @@
 	gender = NEUTER
 	origin_tech = "engineering=3;combat=1"
 	throwforce = 5
+	var/weaken = 0
 
 /obj/item/weapon/restraints/legcuffs/bola/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback)
 	if(!..())

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -330,7 +330,6 @@
 	gender = NEUTER
 	origin_tech = "engineering=3;combat=1"
 	throwforce = 5
-	var/weaken = 0
 
 /obj/item/weapon/restraints/legcuffs/bola/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback)
 	if(!..())
@@ -348,11 +347,10 @@
 		C.update_inv_legcuffed()
 		feedback_add_details("handcuffs","B")
 		to_chat(C, "<span class='userdanger'>\The [src] ensnares you!</span>")
-		C.Weaken(weaken)
 
 /obj/item/weapon/restraints/legcuffs/bola/raider
 	name = "raiding bola"
-	desc = "A classic bola used by raiders to weaken and capture their victims."
+	desc = "A classic bola used by raiders to snare and eventually capture their victims."
 	icon_state = "bola_r"
 	breakouttime = 50 //Slightly harder to break out of
 
@@ -362,7 +360,6 @@
 	icon_state = "bola_t"
 	breakouttime = 100 //Way harder to break out of
 	throwforce = 10
-	weaken = 1
 
 /obj/item/weapon/restraints/legcuffs/bola/energy //For Security
 	name = "energy bola"

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -12,3 +12,27 @@
 	if(damage_flag == "melee" && damage_amount < 20)
 		return 0
 	. = ..()
+	
+	
+/obj/structure/closet/enclave_closet
+	name = "Enclave closet"
+	desc = "It's a holotag locked closet."
+	locked = 1
+	icon_state = "secure"
+	req_access = list(70)
+	obj_integrity = 600
+	max_integrity = 600
+	armor = list(melee = 95, bullet = 95, laser = 95, energy = 95, bomb = 0, bio = 0, rad = 0, fire = 95, acid = 95)
+	secure = 1
+	
+		
+/obj/structure/closet/brotherhood_closet
+	name = "Brotherhood closet"
+	desc = "It's a holotag locked closet."
+	locked = 1
+	icon_state = "secure"
+	req_access = list(69)
+	obj_integrity = 600
+	max_integrity = 600
+	armor = list(melee = 95, bullet = 95, laser = 95, energy = 95, bomb = 0, bio = 0, rad = 0, fire = 95, acid = 95)
+	secure = 1

--- a/code/modules/fallout/misc/jobs/job/brotherhood.dm
+++ b/code/modules/fallout/misc/jobs/job/brotherhood.dm
@@ -48,7 +48,7 @@
 
 	outfit = /datum/outfit/job/elder
 
-	access = list(access_brotherhood)
+	access = list(69)
 	minimal_access = list()
 
 /datum/outfit/job/elder
@@ -109,7 +109,7 @@
 	/obj/item/clothing/suit/f13/mantle_liz
 	)
 
-	access = list(access_brotherhood)
+	access = list(69)
 	minimal_access = list()
 
 /datum/outfit/job/hpaladin
@@ -167,7 +167,7 @@
 	/obj/item/clothing/suit/f13/mantle_liz
 	)
 
-	access = list(access_brotherhood)
+	access = list(69)
 	minimal_access = list()
 
 /datum/outfit/job/hscribe
@@ -227,7 +227,7 @@
 	/obj/item/clothing/suit/f13/mantle_liz
 	)
 
-	access = list(access_brotherhood)
+	access = list(69)
 	minimal_access = list()
 
 /datum/outfit/job/paladin
@@ -286,7 +286,7 @@
 
 	outfit = /datum/outfit/job/knight
 
-	access = list(access_brotherhood)
+	access = list(69)
 	minimal_access = list()
 
 /datum/outfit/job/knight
@@ -344,7 +344,7 @@
 	/obj/item/clothing/suit/f13/mantle_liz
 	)
 
-	access = list(access_brotherhood)
+	access = list(69)
 	minimal_access = list()
 
 /datum/outfit/job/scribe

--- a/code/modules/fallout/misc/jobs/job/enclave.dm
+++ b/code/modules/fallout/misc/jobs/job/enclave.dm
@@ -12,7 +12,7 @@
 	spawn_positions = 1
 	supervisors = "the Enclave Central Command"
 	selection_color = "#ec9d9d"
-	minimal_player_age = 7
+	minimal_player_age = 14
 	whitelist_on = 0
 
 	allowed_packs = list("starter", "cigarettes", "bard", "tesla", "super_ten", "holsters")
@@ -44,7 +44,7 @@
 
 	outfit = /datum/outfit/job/colonel
 
-	access = list(70)
+	access = list(12, 20, 63, 70) //adding vault access perms given that the Enclave has pre-war vault control codes, since the faction is being moved off-map and whitelisted, means they dont have to search for vault stuff to get into the vault if an event calls for it.
 	minimal_access = list()
 
 /datum/outfit/job/colonel
@@ -74,6 +74,7 @@
 	supervisors = "the Colonel"
 	selection_color = "#ec9d9d"
 	minimal_player_age = 7
+	whitelist_on = 0
 
 	allowed_packs = list("starter", "cigarettes", "bard", "tesla", "super_ten", "holsters")
 
@@ -107,7 +108,7 @@
 
 	outfit = /datum/outfit/job/enclave_lieutenant
 
-	access = list(70)
+	access = list(12, 20, 63, 70) //adding vault access perms given that the Enclave has pre-war vault control codes, since the faction is being moved off-map and whitelisted, means they dont have to search for vault stuff to get into the vault if an event calls for it.
 	minimal_access = list()
 
 /datum/outfit/job/enclave_lieutenant
@@ -138,6 +139,7 @@
 	supervisors = "The Colonel"
 	selection_color = "#ec9d9d"
 	minimal_player_age = 7
+	whitelist_on = 0
 
 	allowed_packs = list("starter", "cigarettes", "bard", "tesla", "super_ten", "holsters")
 
@@ -168,7 +170,7 @@
 
 	outfit = /datum/outfit/job/enclave_private
 
-	access = list(70)
+	access = list(12, 20, 63, 70) //adding vault access perms given that the Enclave has pre-war vault control codes, since the faction is being moved off-map and whitelisted, means they dont have to search for vault stuff to get into the vault if an event calls for it.
 	minimal_access = list()
 
 /datum/outfit/job/enclave_private
@@ -198,6 +200,7 @@
 	supervisors = "The Colonel"
 	selection_color = "#ec9d9d"
 	minimal_player_age = 7
+	whitelist_on = 0
 
 	allowed_packs = list("starter", "cigarettes", "bard", "super_ten", "holsters")
 
@@ -226,7 +229,7 @@
 
 	outfit = /datum/outfit/job/enclave_private
 
-	access = list(70)
+	access = list(12, 20, 63, 70) //adding vault access perms given that the Enclave has pre-war vault control codes, since the faction is being moved off-map and whitelisted, means they dont have to search for vault stuff to get into the vault if an event calls for it.
 	minimal_access = list()
 
 /datum/outfit/job/enclave_recruit
@@ -257,6 +260,7 @@
 	supervisors = "The Colonel"
 	selection_color = "#ec9d9d"
 	minimal_player_age = 7
+	whitelist_on = 0
 
 	allowed_packs = list("starter", "cigarettes", "bard", "super_ten", "holsters")
 
@@ -285,8 +289,7 @@
 	)
 
 	outfit = /datum/outfit/job/enclave_private
-
-	access = list(70)
+	access = list(12, 20, 63, 70) //adding vault access perms given that the Enclave has pre-war vault control codes, since the faction is being moved off-map and whitelisted, means they dont have to search for vault stuff to get into the vault if an event calls for it.
 	minimal_access = list()
 
 /datum/outfit/job/enclave_recruit

--- a/code/modules/fallout/misc/jobs/job/ncr.dm
+++ b/code/modules/fallout/misc/jobs/job/ncr.dm
@@ -44,7 +44,7 @@
 
 	outfit = /datum/outfit/job/captain
 
-	access = list(71)
+	access = list(access_ncr)
 	minimal_access = list()
 
 /datum/outfit/job/captain
@@ -303,7 +303,7 @@
 	uniform = /obj/item/clothing/under/f13/ncr
 	shoes = /obj/item/clothing/shoes/f13/military/ncr
 	suit = /obj/item/clothing/suit/armor/f13/ncr/soldier
-	head = /obj/item/clothing/head/helmet/ncr/trooper
+	head = /obj/item/clothing/head/helmet/f13/trooper
 	glasses = /obj/item/clothing/glasses/f13/biker
 	belt = /obj/item/weapon/storage/belt/military/army
 	weapon = /obj/item/weapon/gun/ballistic/automatic/assault_rifle

--- a/code/modules/fallout/misc/jobs/job/ncr.dm
+++ b/code/modules/fallout/misc/jobs/job/ncr.dm
@@ -44,7 +44,7 @@
 
 	outfit = /datum/outfit/job/captain
 
-	access = list(access_ncr)
+	access = list(71)
 	minimal_access = list()
 
 /datum/outfit/job/captain

--- a/code/modules/fallout/obj/chems.dm
+++ b/code/modules/fallout/obj/chems.dm
@@ -3,7 +3,7 @@
 /obj/item/weapon/reagent_containers/pill/patch/healingpowder
 	name = "healing powder"
 	desc = "A foul-smelling primitive healing medicine.<br>It is widespread in the wasteland due to easy production - all kinds of Wastelanders from Settlers to Mercenaries use it to heal minor injuries.<br>Soldiers of the Legion use healing powder as their primary source of medicine and healing, since the Legion bans the use of other chems, such as stimpaks."
-	list_reagents = list("omnizine" = 15, "salglu_solution" = 10, "morphine" = 4.5, "musclestimulant" = 2) // added morphine to the mix to prevent stacking a bunch of healing powders together, and to add the drowsiness drawback from FO2.
+	list_reagents = list("omnizine" = 15, "salglu_solution" = 10, "morphine" = 2.6, "musclestimulant" = 8) // added morphine to the mix to prevent stacking a bunch of healing powders together, and to add the drowsiness drawback from FO2.
 	icon = 'icons/fallout/objects/medicine/chemical.dmi'
 	icon_state = "heal_powder"
 	item_state = "bandaid"

--- a/code/modules/fallout/obj/clothing/head/helmet.dm
+++ b/code/modules/fallout/obj/clothing/head/helmet.dm
@@ -651,18 +651,6 @@
 	self_weight = 2
 	flash_protect = 2
 	
-/obj/item/clothing/head/helmet/ncr/trooper
-	name = "trooper helmet"
-	desc = "A dully-colored helmet designed to provide troopers a basic head protection.<br>It has a very rough \"mass-produced\" look to it, as it is issued to all NCR soldiers and MPs."
-	icon_state = "trooper"
-	item_state = "trooper"
-	armor = list(melee = 30, bullet = 20, laser = 10, energy = 10, bomb = 20, bio = 0, rad = 0, fire = 20, acid = 10)
-	flags_inv = HIDEEARS|HIDEHAIR
-	put_on_delay = 10
-	strip_delay = 45
-	resistance_flags = FIRE_PROOF
-	self_weight = 1
-
 /obj/item/clothing/head/helmet/f13/trooper
 	name = "trooper helmet"
 	desc = "A dully-colored helmet designed to provide troopers a basic head protection.<br>It has a very rough \"mass-produced\" look to it, as it is issued to all NCR soldiers and MPs."

--- a/code/modules/fallout/obj/clothing/head/helmet.dm
+++ b/code/modules/fallout/obj/clothing/head/helmet.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/fallout/clothing/hats.dmi'
 
 /obj/item/clothing/head/helmet/f13/broken
-	name = "broken t-41d power helmet"
+	name = "broken t-45d power helmet"
 	desc = "This power armor helmet is so decrepit and battle-worn that it has ceased its primary function of protecting the wearer from harm.<br>It can still provide some very basic protection."
 	icon_state = "broken"
 	item_state = "broken"

--- a/code/modules/fallout/obj/clothing/head/helmet.dm
+++ b/code/modules/fallout/obj/clothing/head/helmet.dm
@@ -657,7 +657,7 @@
 	icon_state = "trooper"
 	item_state = "trooper"
 	armor = list(melee = 30, bullet = 20, laser = 10, energy = 10, bomb = 20, bio = 0, rad = 0, fire = 20, acid = 10)
-	flags_inv = HIDEEARS
+	flags_inv = HIDEEARS|HIDEHAIR
 	put_on_delay = 10
 	strip_delay = 30
 	resistance_flags = FIRE_PROOF

--- a/code/modules/fallout/obj/clothing/suits/armor.dm
+++ b/code/modules/fallout/obj/clothing/suits/armor.dm
@@ -158,7 +158,7 @@
 	icon_state = "legrecruit"
 	item_state = "legrecruit"
 	body_parts_covered = CHEST|GROIN|LEGS|FEET
-	armor = list(melee = 35, bullet = 25, laser = 10, energy = 10, bomb = 5, bio = 15, rad = 10, fire = 10, acid = 10)
+	armor = list(melee = 35, bullet = 30, laser = 10, energy = 10, bomb = 5, bio = 15, rad = 10, fire = 10, acid = 10)
 	put_on_delay = 60
 	strip_delay = 60
 	self_weight = 4
@@ -169,7 +169,7 @@
 	icon_state = "legrecruit"
 	item_state = "legrecruit"
 	body_parts_covered = CHEST|GROIN|LEGS|FEET
-	armor = list(melee = 45, bullet = 30, laser = 10, energy = 10, bomb = 5, bio = 15, rad = 10, fire = 10, acid = 10)
+	armor = list(melee = 45, bullet = 35, laser = 10, energy = 10, bomb = 5, bio = 15, rad = 10, fire = 10, acid = 10)
 	put_on_delay = 60
 	strip_delay = 60
 	self_weight = 4
@@ -180,7 +180,7 @@
 	icon_state = "legvexil"
 	item_state = "legvexil"
 	body_parts_covered = CHEST|GROIN|LEGS|FEET
-	armor = list(melee = 60, bullet = 30, laser = 20, energy = 15, bomb = 5, bio = 15, rad = 10, fire = 10, acid = 10)
+	armor = list(melee = 60, bullet = 35, laser = 20, energy = 15, bomb = 5, bio = 15, rad = 10, fire = 10, acid = 10)
 	put_on_delay = 60
 	strip_delay = 60
 	self_weight = 5
@@ -191,7 +191,7 @@
 	icon_state = "legcenturion"
 	item_state = "legcenturion"
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS
-	armor = list(melee = 75, bullet = 40, laser = 25, energy = 15, bomb = 10, bio = 15, rad = 10, fire = 10, acid = 10)
+	armor = list(melee = 75, bullet = 45, laser = 25, energy = 15, bomb = 10, bio = 15, rad = 10, fire = 10, acid = 10)
 	put_on_delay = 60
 	strip_delay = 60
 	self_weight = 8
@@ -202,7 +202,7 @@
 	icon_state = "legcenturion"
 	item_state = "legcenturion"
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS
-	armor = list(melee = 75, bullet = 50, laser = 25, energy = 25, bomb = 10, bio = 15, rad = 20, fire = 20, acid = 20)
+	armor = list(melee = 75, bullet = 55, laser = 25, energy = 25, bomb = 10, bio = 15, rad = 20, fire = 20, acid = 20)
 	put_on_delay = 60
 	strip_delay = 60
 	self_weight = 10
@@ -213,7 +213,7 @@
 	icon_state = "leglegate"
 	item_state = "leglegate"
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS
-	armor = list(melee = 95, bullet = 55, laser = 25, energy = 25, bomb = 35, bio = 35, rad = 20, fire = 20, acid = 20)
+	armor = list(melee = 95, bullet = 65, laser = 25, energy = 25, bomb = 35, bio = 35, rad = 20, fire = 20, acid = 20)
 	put_on_delay = 60
 	strip_delay = 60
 	resistance_flags = FIRE_PROOF | ACID_PROOF
@@ -227,7 +227,7 @@
 	icon_state = "combat_mk1"
 	item_state = "combat_mk1"
 	body_parts_covered = CHEST|GROIN|LEGS|FEET
-	armor = list(melee = 55, bullet = 55, laser = 20, energy = 10, bomb = 45, bio = 35, rad = 25, fire = 25, acid = 25)
+	armor = list(melee = 55, bullet = 60, laser = 20, energy = 10, bomb = 45, bio = 35, rad = 25, fire = 25, acid = 25)
 	put_on_delay = 60
 	strip_delay = 60
 	self_weight = 5
@@ -238,7 +238,7 @@
 	icon_state = "combat_mk2"
 	item_state = "combat_mk2"
 	body_parts_covered = CHEST|GROIN|LEGS|FEET
-	armor = list(melee = 70, bullet = 60, laser = 20, energy = 15, bomb = 45, bio = 35, rad = 25, fire = 25, acid = 25)
+	armor = list(melee = 70, bullet = 70, laser = 20, energy = 15, bomb = 45, bio = 35, rad = 25, fire = 25, acid = 25)
 	put_on_delay = 60
 	strip_delay = 60
 	self_weight = 2
@@ -251,7 +251,7 @@
 	icon_state = "ncr_armor1"
 	item_state = "ncr_armor1"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	armor = list(melee = 10, bullet = 30, laser = 5, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 10, acid = 0)
+	armor = list(melee = 15, bullet = 45, laser = 5, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 10, acid = 0)
 	put_on_delay = 50
 	strip_delay = 50
 	resistance_flags = FIRE_PROOF

--- a/code/modules/fallout/projectiles/ammunition/energy.dm
+++ b/code/modules/fallout/projectiles/ammunition/energy.dm
@@ -23,7 +23,7 @@
 
 /obj/item/ammo_casing/energy/laser/rcw
 	delay = 1
-	e_cost = 50 //20 shots per mag.
+	e_cost = 40 //5 shots per burst and each shot uses 40 e_cost. at 200 energy per burst and 1000 energy per power cell this results in total mag size of 5 bursts/25 shots before requiring a new cell
 	projectile_type = /obj/item/projectile/beam/laser/rcw
 	randomspread = 1
 	variance = 8

--- a/code/modules/fallout/projectiles/ammunition/energy.dm
+++ b/code/modules/fallout/projectiles/ammunition/energy.dm
@@ -18,12 +18,12 @@
 	delay = 0
 	pellets = 3
 	variance = 25
-	e_cost = 85 //this does not apply per pellet for some reason, an increased cost should mean that you cant just fire it 60 times per magazine. It's a really fucking lethal weapon without being spammable too.
+	e_cost = 100 //this does not apply per pellet for some reason, an increased cost should mean that you cant just fire it 60 times per magazine. It's a really fucking lethal weapon without being spammable too.
 	randomspread = 0
 
 /obj/item/ammo_casing/energy/laser/rcw
 	delay = 1
-	e_cost = 35 //cost increased because its super spammable with only 10pts, literally like 30 clicks to empty magazine and like 90 projectiles total.
+	e_cost = 40 //cost increased because its super spammable with only 10pts, literally like 30 clicks to empty magazine and like 90 projectiles total.
 	projectile_type = /obj/item/projectile/beam/laser/rcw
 	randomspread = 1
 	variance = 8
@@ -33,19 +33,19 @@
 
 /obj/item/ammo_casing/energy/laser/rifle
 	delay = 4
-	e_cost = 35 //energy weapons use less power than plasma weapons, reduction here to bring it in line with AER13.
+	e_cost = 25 //energy weapons use less power than plasma weapons, reduction here to bring it in line with AER13.
 	randomspread = 1
 	variance = 4
 
 /obj/item/ammo_casing/energy/laser/rifle/aer13
 	delay = 2
-	e_cost = 35
+	e_cost = 25
 
 /obj/item/ammo_casing/energy/laser/rifle/tri
 	delay = 0
 	pellets = 3
 	variance = 25
-	e_cost = 85 //same deal as multiplas above, doesnt apply per pellet so has been increased to prevent near infinite ammo/solo 2 deathclaws with 1 magazine.
+	e_cost = 100 //same deal as multiplas above, doesnt apply per pellet so has been increased to prevent near infinite ammo/solo 2 deathclaws with 1 magazine.
 	randomspread = 0
 
 /obj/item/ammo_casing/energy/laser/laer

--- a/code/modules/fallout/projectiles/ammunition/energy.dm
+++ b/code/modules/fallout/projectiles/ammunition/energy.dm
@@ -23,7 +23,7 @@
 
 /obj/item/ammo_casing/energy/laser/rcw
 	delay = 1
-	e_cost = 40 //cost increased because its super spammable with only 10pts, literally like 30 clicks to empty magazine and like 90 projectiles total.
+	e_cost = 50 //20 shots per mag.
 	projectile_type = /obj/item/projectile/beam/laser/rcw
 	randomspread = 1
 	variance = 8

--- a/code/modules/fallout/projectiles/ammunition/energy.dm
+++ b/code/modules/fallout/projectiles/ammunition/energy.dm
@@ -57,7 +57,7 @@
 
 /obj/item/ammo_casing/energy/laser/gauss2mm
 	delay = 2
-	e_cost = 1000
+	e_cost = 2250
 	randomspread = 0
 	projectile_type = /obj/item/projectile/beam/laser/gauss2mm
 	variance = 4

--- a/code/modules/fallout/projectiles/guns/energy.dm
+++ b/code/modules/fallout/projectiles/guns/energy.dm
@@ -165,7 +165,7 @@
 
 /obj/item/weapon/gun/energy/laser/gaussrifle
 	name = "gauss rifle"
-	desc = "The Gauss Rifle comes loaded with a magazine filled with slivers of inert metal allowing for thousands of shots before requiring a new magazine. Using a substantial amount of charge, a power cell activates magnetic coils to hurtle these slugs at incredible speeds. It seems standard microfusion cells however will not do the job, this weapon requires a more advanced power cell which must be researched."
+	desc = "The Gauss Rifle comes loaded with a magazine filled with slivers of inert metal allowing for hundreds of shots before requiring a new magazine. Using a substantial amount of charge, a power cell activates magnetic coils to hurtle these slugs at incredible speeds. It seems standard microfusion cells however will not do the job, this weapon requires a more advanced power cell which must be researched."
 	icon = 'icons/fallout/objects/guns/energy.dmi'
 	icon_state = "gaussrifle"
 	item_state = "gaussrifle"

--- a/code/modules/fallout/projectiles/guns/energy.dm
+++ b/code/modules/fallout/projectiles/guns/energy.dm
@@ -165,7 +165,7 @@
 
 /obj/item/weapon/gun/energy/laser/gaussrifle
 	name = "gauss rifle"
-	desc = "The Gauss Rifle is loaded with a magazine filled with slivers of inert metal. Using a substantial amount of charge, a power cell activates magnetic coils to hurtle these slugs at incredible speeds."
+	desc = "The Gauss Rifle comes loaded with a magazine filled with slivers of inert metal allowing for thousands of shots before requiring a new magazine. Using a substantial amount of charge, a power cell activates magnetic coils to hurtle these slugs at incredible speeds. It seems standard microfusion cells however will not do the job, this weapon requires a more advanced power cell which must be researched."
 	icon = 'icons/fallout/objects/guns/energy.dmi'
 	icon_state = "gaussrifle"
 	item_state = "gaussrifle"

--- a/code/modules/fallout/projectiles/guns/energy.dm
+++ b/code/modules/fallout/projectiles/guns/energy.dm
@@ -170,9 +170,9 @@
 	icon_state = "gaussrifle"
 	item_state = "gaussrifle"
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/gauss2mm)
-	w_class = 3
+	w_class = 4
 	zoomable = TRUE
 	zoom_amt = 22
 	slot_flags = SLOT_BACK
-	weapon_weight = WEAPON_MEDIUM
-	w_class = WEIGHT_CLASS_BULKY
+	weapon_weight = WEAPON_HEAVY
+	w_class = WEIGHT_CLASS_HUGE

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/stock_parts/cell
 	name = "Microfusion cell"
-	desc = "A rechargable miniature fusion reaction contained in a power cell."
+	desc = "A rechargable miniature fusion reaction contained in a compact power cell, roughly the size of a golf ball."
 	icon = 'icons/obj/power.dmi'
 	icon_state = "cell"
 	item_state = "cell"

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/stock_parts/cell
 	name = "Microfusion cell"
-	desc = "A rechargable miniature fusion reaction contained in a compact power cell, roughly the size of a golf ball."
+	desc = "A rechargable miniature fusion reaction contained within a compact power cell, roughly the size of a golf ball."
 	icon = 'icons/obj/power.dmi'
 	icon_state = "cell"
 	item_state = "cell"

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/stock_parts/cell
 	name = "Microfusion cell"
-	desc = "A rechargable electrochemical power cell."
+	desc = "A rechargable miniature fusion reaction contained in a power cell."
 	icon = 'icons/obj/power.dmi'
 	icon_state = "cell"
 	item_state = "cell"
@@ -198,13 +198,13 @@
 
 /obj/item/weapon/stock_parts/cell/high
 	name = "high-capacity Microfusion cell"
-	origin_tech = "powerstorage=1"
+	origin_tech = "powerstorage=2"
 	icon_state = "hcell"
 	maxcharge = 2250
-	materials = list(MAT_METAL = 25000, MAT_GLASS = 25000)
+	materials = list(MAT_METAL = 30000, MAT_GLASS = 30000)
 	rating = 3
-	chargerate = 250
-	self_recharge = 1
+	chargerate = 450
+	self_recharge = 0 / works better without self charging in my view, gave it a faster recharge in ports so it can be recharged faster rather than just being self charging.
 
 /obj/item/weapon/stock_parts/cell/high/plus
 	name = "high-capacity power cell+"

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -204,7 +204,7 @@
 	materials = list(MAT_METAL = 30000, MAT_GLASS = 30000)
 	rating = 3
 	chargerate = 450
-	self_recharge = 0 / works better without self charging in my view, gave it a faster recharge in ports so it can be recharged faster rather than just being self charging.
+	self_recharge = 0 //works better without self charging in my view, gave it a faster recharge in ports so it can be recharged faster rather than just being self charging.
 
 /obj/item/weapon/stock_parts/cell/high/plus
 	name = "high-capacity power cell+"

--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -145,11 +145,6 @@
 	desc = "A 5.56mm bullet casing."
 	caliber = "a556"
 	projectile_type = /obj/item/projectile/bullet/weakbullet3
-	
-/obj/item/ammo_casing/a556AP
-	desc = "A 5.56mm armour piercing bullet casing."
-	caliber = "a556"
-	projectile_type = /obj/item/projectile/bullet/armourpiercing556
 
 /obj/item/ammo_casing/a40mm
 	name = "40mm HE shell"

--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -145,6 +145,11 @@
 	desc = "A 5.56mm bullet casing."
 	caliber = "a556"
 	projectile_type = /obj/item/projectile/bullet/weakbullet3
+	
+/obj/item/ammo_casing/a556AP
+	desc = "A 5.56mm armour piercing bullet casing."
+	caliber = "a556"
+	projectile_type = /obj/item/projectile/bullet/armourpiercing556
 
 /obj/item/ammo_casing/a40mm
 	name = "40mm HE shell"

--- a/code/modules/projectiles/boxes_magazines/external_mag.dm
+++ b/code/modules/projectiles/boxes_magazines/external_mag.dm
@@ -232,6 +232,14 @@
 	caliber = "a556"
 	max_ammo = 20
 	multiple_sprites = 2
+	
+/obj/item/ammo_box/magazine/m556ap
+	name = "rifle magazine (5.56mm armour piercing)"
+	icon_state = "5.56m"
+	ammo_type = /obj/item/ammo_casing/a556AP
+	caliber = "a556"
+	max_ammo = 20
+	multiple_sprites = 2
 
 /obj/item/ammo_box/magazine/falmag
 	name = "rifle magazine (.308 Winchester)"

--- a/code/modules/projectiles/boxes_magazines/external_mag.dm
+++ b/code/modules/projectiles/boxes_magazines/external_mag.dm
@@ -232,14 +232,6 @@
 	caliber = "a556"
 	max_ammo = 20
 	multiple_sprites = 2
-	
-/obj/item/ammo_box/magazine/m556ap
-	name = "rifle magazine (5.56mm armour piercing)"
-	icon_state = "5.56m"
-	ammo_type = /obj/item/ammo_casing/a556AP
-	caliber = "a556"
-	max_ammo = 20
-	multiple_sprites = 2
 
 /obj/item/ammo_box/magazine/falmag
 	name = "rifle magazine (.308 Winchester)"

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -28,7 +28,7 @@
 	name = "2mm bolt"
 	damage = 100
 	armour_penetration = 200
-	dismemberment = 60 //reduced instant decap on headshot rather than just crit
+	dismemberment = 60 //reduced instant decap on headshot, should result in less 1shot kills while still insta critting
 	icon_state = "2mm"
 	pass_flags = PASSTABLE
 	light_color = LIGHT_COLOR_BLUE

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -26,9 +26,9 @@
 
 /obj/item/projectile/beam/laser/gauss2mm
 	name = "2mm bolt"
-	damage = 80 //slightly reduced damage, will still 1shot most things though.
+	damage = 100
 	armour_penetration = 200
-	dismemberment = 100
+	dismemberment = 60 //reduced instant decap on headshot rather than just crit
 	icon_state = "2mm"
 	pass_flags = PASSTABLE
 	light_color = LIGHT_COLOR_BLUE

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -26,7 +26,7 @@
 
 /obj/item/projectile/beam/laser/gauss2mm
 	name = "2mm bolt"
-	damage = 100
+	damage = 80 //slightly reduced damage, will still 1shot most things though.
 	armour_penetration = 200
 	dismemberment = 100
 	icon_state = "2mm"

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -70,11 +70,6 @@
 	armour_penetration = 40
 	dismemberment = 0
 
-/obj/item/projectile/bullet/armourpiercing556 //5.56 armour piercing round. designed for piercing heavy armour but wont necessarily do much damage
-	damage = 8.4
-	armour_penetration = 90
-	dismemberment = 0
-
 /obj/item/projectile/bullet/pellet
 	name = "pellet"
 	damage = 15

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -313,7 +313,7 @@
 /obj/item/projectile/bullet/sniper
 	speed = 0		//360 alwaysscope.
 	damage = 60
-	stamina = 60
+	stamina = 60 //will now cause a stun after 2 hits on the same target, lasts for roughly 7 seconds if they dont have stamina regenerating chems in hte bloodstream
 	dismemberment = 2
 	armour_penetration = 55 //higher ap value
 	var/breakthings = FALSE

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -1,5 +1,5 @@
 /obj/item/projectile/bullet
-	name = "bullet"
+	name = "bullet" //this projectile is used by .357s, 7.62s and even .50 AE, so current statline fits rather well.
 	icon_state = "bullet"
 	damage = 50
 	damage_type = BRUTE
@@ -15,15 +15,14 @@
 	stamina = 80
 	dismemberment = 0
 
-/obj/item/projectile/bullet/weakbullet2 //detective revolver instastuns, but multiple shots are better for keeping punks down
+/obj/item/projectile/bullet/weakbullet2 //removing weaken from this as bullets causing instant knockdown is pretty heinous.
 	damage = 26
-	weaken = 3
 	stamina = 50
-	dismemberment = 0.3
+	dismemberment = 0
 
-/obj/item/projectile/bullet/weakbullet3
-	damage = 28
-	dismemberment = 0.3
+/obj/item/projectile/bullet/weakbullet3 // lowering damage on tihs one slightly, used by 9mms.
+	damage = 22
+	dismemberment = 0
 
 /obj/item/projectile/bullet/toxinbullet
 	damage = 10
@@ -32,32 +31,31 @@
 
 /obj/item/projectile/bullet/incendiary/firebullet
 	damage = 10
-	dismemberment = 0.3
+	dismemberment = 0
 
 /obj/item/projectile/bullet/sniper/haemorrhage/deagle
 	name = "bullet"
 	damage = 60
-	dismemberment = 0.5
+	dismemberment = 0.25
 
 /obj/item/projectile/bullet/deagle
 	name = "bullet"
-	damage = 55
-	dismemberment = 0.7
+	damage = 40 //lowering damage slightly to offset haemmorhage rounds.
+	dismemberment = 0.25
 
 /obj/item/projectile/bullet/deagle/two
 	name = "bullet"
-	damage = 70
-	dismemberment = 0.7
+	damage = 55 //lowering damage as used by deagle skins, really shouldnt be doing like 15 extra damage.
+	dismemberment = 0.25
 
-/obj/item/projectile/bullet/webley
+/obj/item/projectile/bullet/webley //low velocity weapon, webley was reliable not necessarily known for its deadliness
 	name = "bullet"
-	damage = 65
+	damage = 35
 	dismemberment = 0.4
 
-/obj/item/projectile/bullet/bulldog
+/obj/item/projectile/bullet/bulldog //stripping weaken again, not a fan of guns causing stuns and think it drastically messes with combat.
 	name = "bullet"
 	damage = 68
-	weaken = 3
 	stamina = 50
 	dismemberment = 0.4
 
@@ -67,15 +65,20 @@
 		C.bleed(100)
 	return ..()
 
-/obj/item/projectile/bullet/armourpiercing
-	damage = 20
-	armour_penetration = 10
-	dismemberment = 0.5
+/obj/item/projectile/bullet/armourpiercing //9mm armour piercing round. designed for piercing heavy armour but wont necessarily do much damage
+	damage = 6.8
+	armour_penetration = 40
+	dismemberment = 0
+
+/obj/item/projectile/bullet/armourpiercing556 //5.56 armour piercing round. designed for piercing heavy armour but wont necessarily do much damage
+	damage = 8.4
+	armour_penetration = 90
+	dismemberment = 0
 
 /obj/item/projectile/bullet/pellet
 	name = "pellet"
 	damage = 15
-	dismemberment = 1
+	dismemberment = 0.4
 
 /obj/item/projectile/bullet/pellet/decimator
 	name = "pellet"
@@ -364,10 +367,10 @@
 /obj/item/projectile/bullet/sniper/penetrator
 	icon_state = "gauss"
 	name = "penetrator round"
-	damage = 60
+	damage = 50 // slightly reduced damage
 	forcedodge = 1
 	dismemberment = 0.8
-	stun = 10
+	stun = 3 //reduced stun duration
 	weaken = 5
 	breakthings = FALSE
 

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -90,16 +90,12 @@
 /obj/item/projectile/bullet/roland
 	name = ".45 round"
 	damage = 90
-	stun = 100
-	weaken = 100
 	dismemberment = 1
 	armour_penetration = 30
 
 /obj/item/projectile/bullet/winchester
 	name = ".30-30 round"
 	damage = 80
-	stun = 50
-	weaken = 30
 	dismemberment = 1
 
 /obj/item/projectile/bullet/pellet/weak/New()
@@ -317,8 +313,7 @@
 /obj/item/projectile/bullet/sniper
 	speed = 0		//360 alwaysscope.
 	damage = 60
-	stun = 8 //stun time reduced, 30 was too much.
-	weaken = 2
+	stamina = 60
 	dismemberment = 2
 	armour_penetration = 55 //higher ap value
 	var/breakthings = FALSE
@@ -332,9 +327,7 @@
 /obj/item/projectile/bullet/sniper/soporific
 	armour_penetration = 0
 	nodamage = 1
-	stun = 0
 	dismemberment = 0
-	weaken = 0
 	breakthings = FALSE
 
 /obj/item/projectile/bullet/sniper/soporific/on_hit(atom/target, blocked = 0)
@@ -347,9 +340,7 @@
 /obj/item/projectile/bullet/sniper/haemorrhage
 	armour_penetration = 15
 	damage = 75
-	stun = 5
 	dismemberment = 1
-	weaken = 3
 	breakthings = FALSE
 
 /obj/item/projectile/bullet/sniper/haemorrhage/on_hit(atom/target, blocked = 0)
@@ -365,8 +356,6 @@
 	damage = 50 // slightly reduced damage
 	forcedodge = 1
 	dismemberment = 0.8
-	stun = 3 //reduced stun duration
-	weaken = 5
 	breakthings = FALSE
 
 

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -316,11 +316,11 @@
 
 /obj/item/projectile/bullet/sniper
 	speed = 0		//360 alwaysscope.
-	damage = 70
-	stun = 30
-	weaken = 5
+	damage = 60
+	stun = 8 //stun time reduced, 30 was too much.
+	weaken = 2
 	dismemberment = 2
-	armour_penetration = 40
+	armour_penetration = 55 //higher ap value
 	var/breakthings = FALSE
 
 /obj/item/projectile/bullet/sniper/on_hit(atom/target, blocked = 0)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -565,7 +565,7 @@
 	description = "A painkiller that allows the patient to move at full speed even in bulky objects. Causes drowsiness and eventually unconsciousness in high doses. Overdose will cause a variety of effects, ranging from minor to lethal."
 	reagent_state = LIQUID
 	color = "#A9FBFB"
-	metabolization_rate = 0.5 * REAGENTS_METABOLISM
+	metabolization_rate = 0.55
 	overdose_threshold = 30
 	addiction_threshold = 25
 

--- a/code/modules/research/designs/power_designs.dm
+++ b/code/modules/research/designs/power_designs.dm
@@ -17,7 +17,7 @@
 	name = "Improved Capacity Microfusion Cell"
 	desc = "An improved capacity Microfusion power cell that holds 2250 units of energy."
 	id = "high_cell"
-	req_tech = list("powerstorage" = 1)
+	req_tech = list("powerstorage" = 2) // stay at 2, requires research once added then can be made at proto, auto or mechfab.
 	build_type = PROTOLATHE | AUTOLATHE | MECHFAB
 	materials = list(MAT_METAL = 25000, MAT_GLASS = 25000)
 	construction_time=30


### PR DESCRIPTION
Changelog:

Adjusted gauss rifle weight category so it must be fired with a twohanded grip. The gauss rifle now also requires 2250 energy to fire, meaning that standard microfusion cells cannot be used for it. The weapon is extremely powerful, limiting it to research is a better option and has been done with these changes.

Fixed tech requirement so high power cells are not available at roundstart and must be researched. Also increased their manufacturing cost, removed self recharging property and increased their recharge rate when plugged into a weapon in a recharger.

Increased energy costs on multiplas and trilaser, decreased energy costs slightly on laser weapons to allow more shots per mag (AER9 is 40 shots per cell)

Increased energy cost on RCW so it loses 1 burst from maximum, current max is 5 bursts or 25 shots.

Reduced damage on sniper (NCR Veteran Ranger's sniper) but boosted AP value so it can pierce power armour more reliably, removed the stunning property but changed it to deal stamina damage. Two hits on a target will put them in a roughly 8 second long stun.

Removed weaken property from bolas so that it no longer stuns, it causes slowdown and can be thrown by legionnaires who are running around very quickly - a ranged stun is not needed. They have guns and throwing spears to deal with targets they cannot get close to, and the stun before was long enough that they could reliably close the gap and finish you off if bola'd.

Boosted ballistic protection across NCR/Legion gear just slightly, enough that 9mm should no longer 4shot but instead 6shot.

Increased morphine filter rate so it no longer causes KO at 6 units, you now need roughly 9 units in hte bloodstream to cause KO.

Added Enclave/Brotherhood holotag linked lockers. Use these when designing faction areas so some random wastelander can't simply open every locker they find.

Normalised access perms in faction files across the board, so they use numbers instead of access_ncr, for example.

Added a power armour training manual into the game as way to get the power armour training martial art. Currently not obtainable anywhere, but placeholder for the future.

Added Vault access perms to the Enclave, given that they will be off map soon - this is to reflect their access to vault control codes for admin events.

Fixed NCR Trooper helmet which had no sprite previously due to being stored in incorrect location. Mappers might need to adjust their spawned helmets within the NCR closets.