### PR TITLE
adjusted robot movement delay

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -17,7 +17,7 @@ REVIVAL_BRAIN_LIFE -1
 ### RENAMING ###
 
 #Uncomment to allow cyborgs to rename themselves at roundstart.  Has no effect on roboticists renaming cyborgs the normal way.
-#RENAME_CYBORG
+RENAME_CYBORG
 
 ### OOC DURING ROUND ###
 #Comment this out if you want OOC to be automatically disabled during the round, it will be enabled during the lobby and after the round end results.
@@ -42,7 +42,7 @@ WALK_DELAY 5
 
 ## The variables below affect the movement of specific mob types.
 HUMAN_DELAY 0
-ROBOT_DELAY 0
+ROBOT_DELAY 2
 MONKEY_DELAY 0
 ALIEN_DELAY 0
 SLIME_DELAY 0


### PR DESCRIPTION
should be slow enough to offset the rather large advantage robots get.

they are not speedy, but durable and can carry many tools. best served to defensive or supporting roles in towns.