### PR TITLE
increased fire delay on gauss rifle

### DIFF
--- a/code/modules/fallout/projectiles/guns/energy.dm
+++ b/code/modules/fallout/projectiles/guns/energy.dm
@@ -202,7 +202,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/gauss2mm)
 	zoomable = TRUE
 	zoom_amt = 22
-	fire_delay = 60
+	fire_delay = 125
 	slot_flags = SLOT_BACK
 	weapon_weight = WEAPON_HEAVY
 	w_class = WEIGHT_CLASS_HUGE


### PR DESCRIPTION
60 was too low, 125 is enough that you can reliably reload a new shot and still have maybe 2 - 3 seconds before firing again, given that this is a sniper rifle, with perfect accuracy, that can 1shot almost anything - should be fine.