### PR TITLE
fixed power armor usability check

### DIFF
--- a/code/modules/fallout/obj/clothing/suits/armor.dm
+++ b/code/modules/fallout/obj/clothing/suits/armor.dm
@@ -1,5 +1,4 @@
 //Fallout 13 general armor directory
-var/powerarmor = 0
 
 /obj/item/clothing/suit/armor/f13
 	icon = 'icons/fallout/clothing/suits.dmi'
@@ -393,14 +392,20 @@ var/powerarmor = 0
 	strip_delay = 300
 	special_defence = PREVENTDISMEMBER
 
-/obj/item/clothing/suit/armor/f13/power_armor/mob_can_equip(mob/user, slot) //THIS PART NEEDS FIXING. CODE CURRENTLY DOES NOT WORK NOR DO FACTIONS HAVE MARTIAL ART APPLIED TO THEM TO PASS THIS CHECK ONCE IT DOES WORK.
-	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		if(powerarmor == 0 && slot == slot_wear_suit)
-			H << "<span class='warning'>You don't have the proper training to operate the power armor!</span>"
-			return 0
-			..()
-	return ..()
+
+
+/////////////////////////POWER ARMOR USABILITY CHECK/////////////////////////
+			
+/obj/item/clothing/suit/armor/f13/power_armor/equipped(mob/living/user, slot)
+	..()
+	if(slot == slot_wear_suit && !is_servant_of_ratvar(user))
+		if(iscarbon(user))
+			to_chat(user, "<span class='heavy_brass'>You lack the training to use power armour!</span>")
+		addtimer(CALLBACK(user, /mob/living.proc/unEquip, src, 1), 1)	
+			
+/////////////////////////POWER ARMOR USABILITY CHECK/////////////////////////	
+	
+
 
 // brotherhood power armors
 
@@ -409,7 +414,7 @@ var/powerarmor = 0
 	desc = "Originally developed and manufactured for the United States Army by American defense contractor West Tek, the T-45d power armor was the first version of power armor to be successfully deployed in battle."
 	icon_state = "t45dpowerarmor"
 	item_state = "t45dpowerarmor"
-	armor = list(melee = 85, bullet = 85, laser = 45, energy = 45, bomb = 55, bio =100, rad = 100, fire = 100, acid = 100)
+	armor = list(melee = 85, bullet = 85, laser = 45, energy = 40, bomb = 55, bio =100, rad = 100, fire = 100, acid = 100)
 	self_weight = 26
 
 /obj/item/clothing/suit/armor/f13/power_armor/t51b
@@ -417,7 +422,7 @@ var/powerarmor = 0
 	desc = "A mass-produced pinnacle of pre-War engineering.<br>Developed in the laboratories of the West Tek Research Facility, the T-51b was deployed at the end of the Anchorage Reclamation, and by January 2077, the armor had become standard issue for American soldiers in the Army's Mechanized Cavalry Regiments."
 	icon_state = "t51bpowerarmor"
 	item_state = "t51bpowerarmor"
-	armor = list(melee = 85, bullet = 90, laser = 50, energy = 50, bomb = 55, bio = 100, rad = 100, fire = 100, acid = 100)
+	armor = list(melee = 85, bullet = 90, laser = 50, energy = 45, bomb = 55, bio = 100, rad = 100, fire = 100, acid = 100)
 	self_weight = 28
 
 /obj/item/clothing/suit/armor/f13/power_armor/t60
@@ -425,7 +430,7 @@ var/powerarmor = 0
 	desc = "Developed in early 2077 after the Anchorage Reclamation, the T-60 series of power armor was designed to eventually replace the T-51b power armor as the pinnacle of powered armor technology in the U.S. military arsenal.<br>Incorporating design elements from the earlier T-45, the T-60 was deployed domestically among U.S. Army units just prior to the dropping of the bombs."
 	icon_state = "t60powerarmor"
 	item_state = "t60powerarmor"
-	armor = list(melee = 85, bullet = 95, laser = 55, energy = 55, bomb = 45, bio = 100, rad = 100, fire = 100, acid = 100)
+	armor = list(melee = 85, bullet = 95, laser = 55, energy = 50, bomb = 45, bio = 100, rad = 100, fire = 100, acid = 100)
 	self_weight = 30
 
 // enclave armors
@@ -435,7 +440,7 @@ var/powerarmor = 0
 	desc = "An advanced suit of armor typically used by the Enclave.<br>It is composed of lightweight metal alloys, reinforced with ceramic castings at key stress points.<br>Additionally, like the T-51b power armor, it includes a recycling system that can convert human waste into drinkable water, and an air conditioning system for it's user's comfort."
 	icon_state = "advanced"
 	item_state = "advanced"
-	armor = list(melee = 95, bullet = 95, laser = 70, energy = 70, bomb = 55, bio = 100, rad = 100, fire = 100, acid = 100)
+	armor = list(melee = 95, bullet = 95, laser = 70, energy = 65, bomb = 55, bio = 100, rad = 100, fire = 100, acid = 100)
 	self_weight = 26
 
 /obj/item/clothing/suit/armor/f13/power_armor/superadvanced
@@ -443,7 +448,7 @@ var/powerarmor = 0
 	desc = "An improved model of advanced power armor used exclusively by the Enclave military forces, developed after the Great War.<br>Like its older brother, the standard advanced power armor, it's matte black with a menacing appearance, but with a few significant differences - it appears to be composed entirely of lightweight ceramic composites rather than the usual combination of metal and ceramic plates.<br>Additionally, like the T-51b power armor, it includes a recycling system that can convert human waste into drinkable water, and an air conditioning system for it's user's comfort."
 	icon_state = "advanced"
 	item_state = "advanced"
-	armor = list(melee = 98, bullet = 98, laser = 80, energy = 80, bomb = 55, bio = 100, rad = 100, fire = 100, acid = 100)
+	armor = list(melee = 98, bullet = 98, laser = 80, energy = 70, bomb = 55, bio = 100, rad = 100, fire = 100, acid = 100)
 	self_weight = 22
 
 /obj/item/clothing/suit/armor/f13/power_armor/shocktrooper
@@ -451,7 +456,7 @@ var/powerarmor = 0
 	desc = "A \"Black Devil\" power armor - a high-end model used exclusively by the Enclave's Department of the Army and developed after the Great War and the destruction of the Enclave Oil Rig in 2241.<br>It is composed entirely of lightweight composites rather than the usual combination of metal and composite plates found on the previous designations of advanced power armor, the mark I and II."
 	icon_state = "shocktrooper" //probably need a new sprite of this to fit with the higher detail style of the new APA
 	item_state = "shocktrooper" //probably need a new sprite of this to fit with the higher detail style of the new APA
-	armor = list(melee = 105, bullet = 105, laser = 85, energy = 85, bomb = 60, bio = 100, rad = 100, fire = 100, acid = 100)
+	armor = list(melee = 105, bullet = 105, laser = 85, energy = 70, bomb = 60, bio = 100, rad = 100, fire = 100, acid = 100)
 	self_weight = 24
 
 /obj/item/clothing/suit/armor/f13/power_armor/tesla
@@ -459,7 +464,7 @@ var/powerarmor = 0
 	desc = "A variant of the Enclave's advanced power armor Mk I, jury-rigged with a Tesla device that is capable of dispersing a large percentage of the damage done by directed-energy attacks.<br>As it's made of complex composite materials designed to block most of energy damage - it's notably weaker against kinetic impacts."
 	icon_state = "tesla" //placeholder will use tesla sprite for now, needs a tesla version of the new APA though.
 	item_state = "tesla" //placeholder will use tesla sprite for now, needs a tesla version of the new APA though.
-	armor = list(melee = 65, bullet = 65, laser = 98, energy = 98, bomb = 55, bio = 100, rad = 100, fire = 100, acid = 100)
+	armor = list(melee = 65, bullet = 65, laser = 98, energy = 80, bomb = 55, bio = 100, rad = 100, fire = 100, acid = 100)
 	self_weight = 26
 
 /obj/item/clothing/suit/armor/f13/power_armor/badmin
@@ -467,7 +472,7 @@ var/powerarmor = 0
 	desc = "Enclave Hellfire armor is a heat-resistant power armor worn by high level Enclave soldiers and the specialized, elite Enclave Hellfire troopers."
 	icon_state = "PLACEHOLDERFORHELLFIRESPRITE!!!" //replacing with error for now since its unsuable anyway, would love a hellfire sprite...
 	item_state = "PLACEHOLDERFORHELLFIRESPRITE!!!" //replacing with error for now since its unsuable anyway, would love a hellfire sprite...
-	armor = list(melee = 105, bullet = 105, laser = 200, energy = 200, bomb = 75, bio = 100, rad = 100, fire = 100, acid = 100) //Burn baby, burn!
+	armor = list(melee = 110, bullet = 110, laser = 200, energy = 200, bomb = 75, bio = 100, rad = 100, fire = 100, acid = 100) //Burn baby, burn!
 	self_weight = 26
 
 //Knights of the Apocalypse
@@ -502,4 +507,3 @@ var/powerarmor = 0
 	desc = "A set of plate armor with tabard for the user's high-visibility during combat."
 	icon_state = "knight_tabard"
 	item_state = "knight_tabard"
-


### PR DESCRIPTION
now checks for antag status, antag status is applied to jobs when they spawn now, jobs have had their pa roundstart loadout stuff removed in favour of storing gear in their offices/barracks.