### PR TITLE
added vault clearance codes

### DIFF
--- a/code/modules/fallout/misc/jobs/job/enclave.dm
+++ b/code/modules/fallout/misc/jobs/job/enclave.dm
@@ -39,7 +39,7 @@
 
 	outfit = /datum/outfit/job/colonel
 
-	access = list(70)
+	access = list(70, 63, 20, 12)
 	minimal_access = list()
 
 /datum/outfit/job/colonel
@@ -97,7 +97,7 @@
 
 	outfit = /datum/outfit/job/enclave_lieutenant
 
-	access = list(70)
+	access = list(70, 63, 20, 12)
 	minimal_access = list()
 
 /datum/outfit/job/enclave_lieutenant


### PR DESCRIPTION
added vault clearance code to colonel/lieutenant given that they would have access to the prewar control systems, just a placeholder for vault access so when enclave are used in admeme events, they dont have to nuke their way into vault - its technically their property.