### PR TITLE
Update eyebot.dm

### DIFF
--- a/code/modules/fallout/mob/npc/eyebot.dm
+++ b/code/modules/fallout/mob/npc/eyebot.dm
@@ -21,6 +21,13 @@
 	health = 70
 	self_weight = 50
 	healable = 0
+	loot = list(	/obj/item/weapon/stock_parts/capacitor/adv = 2,
+			/obj/item/crafting/diode = 1,
+			/obj/item/crafting/transistor = 2,
+			/obj/item/crafting/resistor = 1,
+			/obj/item/stack/sheet/metal/five = 1,
+			/obj/item/weapon/stock_parts/cell = 1
+			)
 
 	faction = list("hostile", "enclave")
 

--- a/code/modules/fallout/mob/npc/eyebot.dm
+++ b/code/modules/fallout/mob/npc/eyebot.dm
@@ -21,7 +21,7 @@
 	health = 70
 	self_weight = 50
 	healable = 0
-	loot = list(	/obj/item/weapon/stock_parts/capacitor/adv = 2,
+	loot = list(/obj/item/weapon/stock_parts/capacitor/adv = 2,
 			/obj/item/crafting/diode = 1,
 			/obj/item/crafting/transistor = 2,
 			/obj/item/crafting/resistor = 1,


### PR DESCRIPTION
adding more loot to eyebots to offset increased presence on map. i placed quite a few around dangerous areas (deathclaw den, north of raider camp), they are easy enough to kill - 2 or 3 shots from most firearms, but laser can be deadly. should be a deterant for newbies and a speedbump for good players. there's also a few in the quarry for the BoS to storm through.