### PR TITLE
Animals can't drive, highway travel tiles can't be sent through each …

### DIFF
--- a/code/__DEFINES/typeids.dm
+++ b/code/__DEFINES/typeids.dm
@@ -2,7 +2,7 @@
 #define TYPEID_NULL "0"
 #define TYPEID_NORMAL_LIST "f"
 //helper macros
-#define GET_TYPEID(ref) ( ( (lentext(ref) <= 10) ? "TYPEID_NULL" : copytext(ref, 4, lentext(ref)-6) ) )
+#define GET_TYPEID(ref) ( ( (length(ref) <= 10) ? "TYPEID_NULL" : copytext(ref, 4, length(ref)-6) ) )
 #define IS_NORMAL_LIST(L) (GET_TYPEID("\ref[L]") == TYPEID_NORMAL_LIST)
 
 

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -16,7 +16,7 @@
 // Run all strings to be used in an SQL query through this proc first to properly escape out injection attempts.
 /proc/sanitizeSQL(t as text)
 	var/sqltext = dbcon.Quote(t);
-	return copytext(sqltext, 2, lentext(sqltext));//Quote() adds quotes around input, we already do that
+	return copytext(sqltext, 2, length(sqltext));//Quote() adds quotes around input, we already do that
 
 /proc/format_table_name(table as text)
 	return sqlfdbktableprefix + table
@@ -311,9 +311,9 @@ proc/html_encode_ru(var/t)
 //is in the other string at the same spot (assuming it is not a replace char).
 //This is used for fingerprints
 	var/newtext = text
-	if(lentext(text) != lentext(compare))
+	if(length(text) != length(compare))
 		return 0
-	for(var/i = 1, i < lentext(text), i++)
+	for(var/i = 1, i < length(text), i++)
 		var/a = copytext(text,i,i+1)
 		var/b = copytext(compare,i,i+1)
 //if it isn't both the same letter, or if they are both the replacement character
@@ -333,7 +333,7 @@ proc/html_encode_ru(var/t)
 	if(!text || !character)
 		return 0
 	var/count = 0
-	for(var/i = 1, i <= lentext(text), i++)
+	for(var/i = 1, i <= length(text), i++)
 		var/a = copytext(text,i,i+1)
 		if(a == character)
 			count++
@@ -544,8 +544,8 @@ var/list/binary = list("0","1")
 			continue
 		var/buffer = ""
 		var/early_culling = TRUE
-		for(var/pos = 1, pos <= lentext(string), pos++)
-			var/let = copytext(string, pos, (pos + 1) % lentext(string))
+		for(var/pos = 1, pos <= length(string), pos++)
+			var/let = copytext(string, pos, (pos + 1) % length(string))
 			if(early_culling && !findtext(let,alphanumeric))
 				continue
 			early_culling = FALSE
@@ -553,9 +553,9 @@ var/list/binary = list("0","1")
 		if(!findtext(buffer,alphanumeric))
 			continue
 		var/punctbuffer = ""
-		var/cutoff = lentext(buffer)
-		for(var/pos = lentext(buffer), pos >= 0, pos--)
-			var/let = copytext(buffer, pos, (pos + 1) % lentext(buffer))
+		var/cutoff = length(buffer)
+		for(var/pos = length(buffer), pos >= 0, pos--)
+			var/let = copytext(buffer, pos, (pos + 1) % length(buffer))
 			if(findtext(let,alphanumeric))
 				break
 			if(findtext(let,punctuation))
@@ -565,8 +565,8 @@ var/list/binary = list("0","1")
 			var/exclaim = FALSE
 			var/question = FALSE
 			var/periods = 0
-			for(var/pos = lentext(punctbuffer), pos >= 0, pos--)
-				var/punct = copytext(punctbuffer, pos, (pos + 1) % lentext(punctbuffer))
+			for(var/pos = length(punctbuffer), pos >= 0, pos--)
+				var/punct = copytext(punctbuffer, pos, (pos + 1) % length(punctbuffer))
 				if(!exclaim && findtext(punct,"!"))
 					exclaim = TRUE
 				if(!question && findtext(punct,"?"))
@@ -588,7 +588,7 @@ var/list/binary = list("0","1")
 			buffer = copytext(buffer, 1, cutoff) + punctbuffer
 		if(!findtext(buffer,alphanumeric))
 			continue
-		if(!buffer || lentext(buffer) > 140 || lentext(buffer) <= cullshort || buffer in accepted)
+		if(!buffer || length(buffer) > 140 || length(buffer) <= cullshort || buffer in accepted)
 			continue
 
 		accepted += buffer

--- a/code/datums/mutations.dm
+++ b/code/datums/mutations.dm
@@ -31,7 +31,7 @@
 	. = on_losing(owner)
 
 /datum/mutation/human/proc/set_se(se_string, on = 1)
-	if(!se_string || lentext(se_string) < DNA_STRUC_ENZYMES_BLOCKS * DNA_BLOCK_SIZE)
+	if(!se_string || length(se_string) < DNA_STRUC_ENZYMES_BLOCKS * DNA_BLOCK_SIZE)
 		return
 	var/before = copytext(se_string, 1, ((dna_block - 1) * DNA_BLOCK_SIZE) + 1)
 	var/injection = num2hex(on ? rand(lowest_value, (256 * 16) - 1) : rand(0, lowest_value - 1), DNA_BLOCK_SIZE)
@@ -43,7 +43,7 @@
 		owner.dna.struc_enzymes = set_se(owner.dna.struc_enzymes, on)
 
 /datum/mutation/human/proc/check_block_string(se_string)
-	if(!se_string || lentext(se_string) < DNA_STRUC_ENZYMES_BLOCKS * DNA_BLOCK_SIZE)
+	if(!se_string || length(se_string) < DNA_STRUC_ENZYMES_BLOCKS * DNA_BLOCK_SIZE)
 		return 0
 	if(hex2num(getblock(se_string, dna_block)) >= lowest_value)
 		return 1

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -512,7 +512,7 @@ var/list/obj/machinery/newscaster/allCasters = list()
 		if(href_list["set_channel_name"])
 			channel_name = stripped_input(usr, "Provide a Feed Channel Name", "Network Channel Handler", "", MAX_NAME_LEN)
 			while (findtext(channel_name," ") == 1)
-				channel_name = copytext(channel_name,2,lentext(channel_name)+1)
+				channel_name = copytext(channel_name,2,length(channel_name)+1)
 			updateUsrDialog()
 		else if(href_list["set_channel_lock"])
 			c_locked = !c_locked

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -117,7 +117,7 @@
 			else
 				line1 = "CARGO"
 				line2 = SSshuttle.supply.getTimerStr()
-				if(lentext(line2) > CHARS_PER_LINE)
+				if(length(line2) > CHARS_PER_LINE)
 					line2 = "Error"
 
 			update_display(line1, line2)

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -41,7 +41,7 @@
 /atom/movable/proc/buckle_mob(mob/living/M, force = 0)
 	if(!buckled_mobs)
 		buckled_mobs = list()
-	if((!can_buckle && !force) || !istype(M) || (M.loc != loc) || M.buckled || (buckled_mobs.len >= max_buckled_mobs) || (buckle_requires_restraints && !M.restrained()) || M == src)
+	if((!can_buckle && !force) || !istype(M) || (M.loc != loc) || M.buckled || (buckled_mobs.len >= max_buckled_mobs) || (buckle_requires_restraints && !M.restrained()) || M == src || istype(M, /mob/living/simple_animal) && istype(src, /obj/vehicle/))
 		return 0
 	if(!M.can_buckle() && !force)
 		if(M == usr)

--- a/code/game/objects/structures/ladders.dm
+++ b/code/game/objects/structures/ladders.dm
@@ -1,7 +1,7 @@
 //LADDER DRAGGING OF PLAYERS HAS BEEN SETUP
-//IT CURRENTLY ONLY FUNCTIONS ON LADDERS WHICH CAN ONLY GO UP OR ONLY GO DOWN. 
+//IT CURRENTLY ONLY FUNCTIONS ON LADDERS WHICH CAN ONLY GO UP OR ONLY GO DOWN.
 //ALL EXISTING LADDERS HAVE BEEN ADJUSTED FOR THIS.
-//PLEASE MAKE SURE ANY LADDERS PLACED ARE NOT ABLE TO CONNECT TO MORE THAN 1 LADDER. 
+//PLEASE MAKE SURE ANY LADDERS PLACED ARE NOT ABLE TO CONNECT TO MORE THAN 1 LADDER.
 //LADDER_MIDDLE IS NOW AN ERROR SPECIFICALLY SO YOU SPOT THIS AND REMEMBER TO FIX IT.
 //SEE ENCLAVE SUBLEVELS BASE IN z2.dmm FOR EXAMPLE
 
@@ -195,11 +195,15 @@ obj/structure/ladder/vent/update_icon()
 		update_icon()
 
 /obj/structure/roadtravel/proc/go_up(mob/user,is_ghost)
+	if(istype(user, src))
+		return
 	if(!is_ghost)
 		up.add_fingerprint(user)
 	user.forceMove(get_turf(up))
 
 /obj/structure/roadtravel/proc/go_down(mob/user,is_ghost)
+	if(istype(user, src))
+		return
 	if(!is_ghost)
 		down.add_fingerprint(user)
 	user.forceMove(get_turf(down))

--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -92,13 +92,13 @@
 					if(!playing || shouldStopPlaying(user))//If the instrument is playing, or special case
 						playing = 0
 						return
-					if(lentext(note) == 0)
+					if(length(note) == 0)
 						continue
 //					to_chat(world, "Parse: [copytext(note,1,2)]")
 					var/cur_note = text2ascii(note) - 96
 					if(cur_note < 1 || cur_note > 7)
 						continue
-					for(var/i=2 to lentext(note))
+					for(var/i=2 to length(note))
 						var/ni = copytext(note,i,i+1)
 						if(!text2num(ni))
 							if(ni == "#" || ni == "b" || ni == "n")
@@ -196,11 +196,11 @@
 			if(!in_range(instrumentObj, usr))
 				return
 
-			if(lentext(t) >= 3072)
+			if(length(t) >= 3072)
 				var/cont = input(usr, "Your message is too long! Would you like to continue editing it?", "", "yes") in list("yes", "no")
 				if(cont == "no")
 					break
-		while(lentext(t) > 3072)
+		while(length(t) > 3072)
 
 		//split into lines
 		spawn()
@@ -215,7 +215,7 @@
 				lines.Cut(51)
 			var/linenum = 1
 			for(var/l in lines)
-				if(lentext(l) > 50)
+				if(length(l) > 50)
 					to_chat(usr, "Line [linenum] too long!")
 					lines.Remove(l)
 				else
@@ -251,7 +251,7 @@
 			return
 		if(lines.len > 50)
 			return
-		if(lentext(newline) > 50)
+		if(length(newline) > 50)
 			newline = copytext(newline, 1, 50)
 		lines.Add(newline)
 
@@ -266,7 +266,7 @@
 		var/content = html_encode_ru(input("Enter your line: ", instrumentObj.name, lines[num]) as text|null)
 		if(!content || !in_range(instrumentObj, usr))
 			return
-		if(lentext(content) > 50)
+		if(length(content) > 50)
 			content = copytext(content, 1, 50)
 		if(num > lines.len || num < 1)
 			return

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1962,7 +1962,7 @@
 	else if(href_list["ac_set_channel_name"])
 		src.admincaster_feed_channel.channel_name = stripped_input(usr, "Provide a Feed Channel Name.", "Network Channel Handler", "")
 		while (findtext(src.admincaster_feed_channel.channel_name," ") == 1)
-			src.admincaster_feed_channel.channel_name = copytext(src.admincaster_feed_channel.channel_name,2,lentext(src.admincaster_feed_channel.channel_name)+1)
+			src.admincaster_feed_channel.channel_name = copytext(src.admincaster_feed_channel.channel_name,2,length(src.admincaster_feed_channel.channel_name)+1)
 		src.access_news_network()
 
 	else if(href_list["ac_set_channel_lock"])
@@ -1996,7 +1996,7 @@
 	else if(href_list["ac_set_new_message"])
 		src.admincaster_feed_message.body = adminscrub(input(usr, "Write your Feed story.", "Network Channel Handler", ""))
 		while (findtext(src.admincaster_feed_message.returnBody(-1)," ") == 1)
-			src.admincaster_feed_message.body = copytext(src.admincaster_feed_message.returnBody(-1),2,lentext(src.admincaster_feed_message.returnBody(-1))+1)
+			src.admincaster_feed_message.body = copytext(src.admincaster_feed_message.returnBody(-1),2,length(src.admincaster_feed_message.returnBody(-1))+1)
 		src.access_news_network()
 
 	else if(href_list["ac_submit_new_message"])
@@ -2043,13 +2043,13 @@
 	else if(href_list["ac_set_wanted_name"])
 		src.admincaster_wanted_message.criminal = adminscrub(input(usr, "Provide the name of the Wanted person.", "Network Security Handler", ""))
 		while(findtext(src.admincaster_wanted_message.criminal," ") == 1)
-			src.admincaster_wanted_message.criminal = copytext(admincaster_wanted_message.criminal,2,lentext(admincaster_wanted_message.criminal)+1)
+			src.admincaster_wanted_message.criminal = copytext(admincaster_wanted_message.criminal,2,length(admincaster_wanted_message.criminal)+1)
 		src.access_news_network()
 
 	else if(href_list["ac_set_wanted_desc"])
 		src.admincaster_wanted_message.body = adminscrub(input(usr, "Provide the a description of the Wanted person and any other details you deem important.", "Network Security Handler", ""))
 		while (findtext(src.admincaster_wanted_message.body," ") == 1)
-			src.admincaster_wanted_message.body = copytext(src.admincaster_wanted_message.body,2,lentext(src.admincaster_wanted_message.body)+1)
+			src.admincaster_wanted_message.body = copytext(src.admincaster_wanted_message.body,2,length(src.admincaster_wanted_message.body)+1)
 		src.access_news_network()
 
 	else if(href_list["ac_submit_wanted"])

--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -288,11 +288,11 @@ var/list/VVpixelmovement = list("step_x", "step_y", "bound_height", "bound_width
 		//	the type with the base type removed from the begaining
 		var/fancytype = types[D.type]
 		if (findtext(fancytype, types[type]))
-			fancytype = copytext(fancytype, lentext(types[type])+1)
-		var/shorttype = copytext("[D.type]", lentext("[type]")+1)
-		if (lentext(shorttype) > lentext(fancytype))
+			fancytype = copytext(fancytype, length(types[type])+1)
+		var/shorttype = copytext("[D.type]", length("[type]")+1)
+		if (length(shorttype) > length(fancytype))
 			shorttype = fancytype
-		if (!lentext(shorttype))
+		if (!length(shorttype))
 			shorttype = "/"
 
 		.["[D]([shorttype])\ref[D]#[i]"] = D

--- a/code/modules/fallout/mob/npc/eyebot.dm
+++ b/code/modules/fallout/mob/npc/eyebot.dm
@@ -76,3 +76,4 @@
 /mob/living/simple_animal/hostile/eyebot/floatingeye/New()
 	..()
 	name = "FEB-[rand(1,99)]"
+

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -213,7 +213,7 @@ var/list/image/ghost_images_simple = list() //this is a list of all ghost images
 	var/r_val
 	var/b_val
 	var/g_val
-	var/color_format = lentext(input_color)
+	var/color_format = length(input_color)
 	if(color_format == 3)
 		r_val = hex2num(copytext(input_color, 1, 2))*16
 		g_val = hex2num(copytext(input_color, 2, 3))*16
@@ -367,7 +367,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		usr << "No area available."
 
 	usr.loc = pick(L)
-	
+
 /mob/dead/observer/verb/follow()
 	set category = "Ghost"
 	set name = "Orbit" // "Haunt"

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -85,8 +85,8 @@
 
 /proc/slur(n)
 	var/phrase = html_decode(n)
-	var/leng = lentext(phrase)
-	var/counter=lentext(phrase)
+	var/leng = length(phrase)
+	var/counter=length(phrase)
 	var/newphrase=""
 	var/newletter=""
 	while(counter>=1)
@@ -120,8 +120,8 @@
 
 /proc/cultslur(n) // Inflicted on victims of a stun talisman
 	var/phrase = html_decode(n)
-	var/leng = lentext(phrase)
-	var/counter=lentext(phrase)
+	var/leng = length(phrase)
+	var/counter=length(phrase)
 	var/newphrase=""
 	var/newletter=""
 	while(counter>=1)

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -16,4 +16,4 @@ Comrade Sully = Sentinel
 bonerman1488 = Sentinel
 Kanoha Shinobi = Sentinel
 Andrewciprioni = Sentinel
-Ace_Ciprioni = Sentinel 
+Ace_Ciprioni = Sentinel

--- a/tools/Redirector/textprocs.dm
+++ b/tools/Redirector/textprocs.dm
@@ -40,12 +40,12 @@ proc
 	/////////////////////
 	dd_hasprefix(text, prefix)
 		var/start = 1
-		var/end = lentext(prefix) + 1
+		var/end = length(prefix) + 1
 		return findtext(text, prefix, start, end)
 
 	dd_hasPrefix(text, prefix)
 		var/start = 1
-		var/end = lentext(prefix) + 1
+		var/end = length(prefix) + 1
 		return findtextEx(text, prefix, start, end)
 
 
@@ -64,8 +64,8 @@ proc
 	// Turning text into lists //
 	/////////////////////////////
 	dd_text2list(text, separator)
-		var/textlength      = lentext(text)
-		var/separatorlength = lentext(separator)
+		var/textlength      = length(text)
+		var/separatorlength = length(separator)
 		var/list/textList   = new /list()
 		var/searchPosition  = 1
 		var/findPosition    = 1
@@ -84,8 +84,8 @@ proc
 					return textList
 
 	dd_text2List(text, separator)
-		var/textlength      = lentext(text)
-		var/separatorlength = lentext(separator)
+		var/textlength      = length(text)
+		var/separatorlength = length(separator)
 		var/list/textList   = new /list()
 		var/searchPosition  = 1
 		var/findPosition    = 1


### PR DESCRIPTION
…other and lentext replaced with length

:cl: 
fix: Eyebots can't drive anymore (simple animals can't be buckled to vehicles)
fix: You can no longer buckle highway travel route tiles into other highway travel routes
fix: Replaced all lentext with length; should stop those warnings being thrown up.
/:cl:

[]: # (Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:)
